### PR TITLE
Treatment plan

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 /tmp
 /out-tsc
 /bazel-out
+/docs
 
 # Node
 /node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,6 @@
 /tmp
 /out-tsc
 /bazel-out
-/docs
 
 # Node
 /node_modules

--- a/docs/frontend-integration/treatment-plan-api.md
+++ b/docs/frontend-integration/treatment-plan-api.md
@@ -1,0 +1,579 @@
+# Integracion Frontend - Treatment Plan API
+
+## Descripcion general
+
+El modulo de Plan de Tratamiento permite crear, consultar, actualizar, cancelar y cambiar el estado de planes asociados a un paciente. Tambien permite administrar los items clinicos/economicos del plan.
+
+Todos los endpoints del modulo estan montados bajo `/api`, requieren token JWT en el header `Authorization: Bearer <token>` y trabajan con ownership implicito a partir del usuario autenticado. El frontend no debe enviar ni asumir `user_id`: el backend valida que el paciente, el plan, los conceptos y los items pertenezcan al usuario autenticado.
+
+Los importes se manejan en el backend. Cada item calcula su `subtotal` con `quantity * unit_price`; el plan recalcula `subtotal` y `total` cuando cambian items o descuento.
+
+## Formato estandar de respuesta
+
+Las respuestas exitosas del modulo usan el wrapper estandar del proyecto:
+
+```ts
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T | null;
+  errors: unknown | null;
+}
+```
+
+```json
+{
+  "success": true,
+  "message": "Plan de tratamiento obtenido correctamente",
+  "data": {},
+  "errors": null
+}
+```
+
+Los errores de negocio del modulo usan el mismo formato:
+
+```json
+{
+  "success": false,
+  "message": "El plan de tratamiento no existe o no pertenece al usuario autenticado",
+  "data": null,
+  "errors": null
+}
+```
+
+Nota: los errores de validacion de `express-validator` se devuelven actualmente con el formato nativo:
+
+```json
+{
+  "errors": [
+    {
+      "type": "field",
+      "msg": "El titulo es obligatorio",
+      "path": "title",
+      "location": "body"
+    }
+  ]
+}
+```
+
+## Endpoints disponibles
+
+| Metodo | URL | Descripcion |
+| --- | --- | --- |
+| `GET` | `/api/patients/:patientId/treatment-plans` | Lista los planes de tratamiento de un paciente. |
+| `POST` | `/api/patients/:patientId/treatment-plans` | Crea un plan de tratamiento para un paciente. |
+| `GET` | `/api/treatment-plans/:id` | Obtiene el detalle de un plan con sus items. |
+| `PUT` | `/api/treatment-plans/:id` | Actualiza datos generales del plan. |
+| `DELETE` | `/api/treatment-plans/:id` | Cancela logicamente el plan. |
+| `PATCH` | `/api/treatment-plans/:id/status` | Actualiza el estado del plan. |
+| `POST` | `/api/treatment-plans/:id/items` | Agrega un item al plan. |
+| `PUT` | `/api/treatment-plans/:id/items/:itemId` | Actualiza un item del plan. |
+| `DELETE` | `/api/treatment-plans/:id/items/:itemId` | Elimina un item del plan. |
+| `PATCH` | `/api/treatment-plans/:id/items/:itemId/status` | Actualiza el estado de un item. |
+
+No hay query params definidos para estos endpoints.
+
+## Contratos por endpoint
+
+### GET `/api/patients/:patientId/treatment-plans`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `GET` |
+| Descripcion | Obtiene todos los planes del paciente, ordenados por `created_at` descendente. |
+| Params | `patientId`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | No aplica. |
+| Response body | `ApiResponse<TreatmentPlan[]>`. La lista no incluye items. |
+| Posibles errores | `400` parametro invalido, `401` token invalido, `404` paciente inexistente o sin ownership, `500` error interno. |
+
+### POST `/api/patients/:patientId/treatment-plans`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `POST` |
+| Descripcion | Crea un plan en estado `DRAFT`. |
+| Params | `patientId`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | `CreateTreatmentPlanRequest`. `title` es obligatorio. |
+| Response body | `ApiResponse<TreatmentPlan>` con status HTTP `201`. |
+| Posibles errores | `400` body invalido o descuento negativo, `401` token invalido, `404` paciente inexistente o sin ownership, `500` error interno. |
+
+### GET `/api/treatment-plans/:id`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `GET` |
+| Descripcion | Obtiene el detalle de un plan y sus items. |
+| Params | `id`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | No aplica. |
+| Response body | `ApiResponse<TreatmentPlan>` con `TreatmentPlanItems` incluido por Sequelize. |
+| Posibles errores | `400` parametro invalido, `401` token invalido, `404` plan inexistente o sin ownership, `500` error interno. |
+
+### PUT `/api/treatment-plans/:id`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `PUT` |
+| Descripcion | Actualiza campos generales del plan. Si cambia `discount`, recalcula totales. |
+| Params | `id`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | `UpdateTreatmentPlanRequest`. Todos los campos son opcionales, pero `title` no puede estar vacio si se envia. |
+| Response body | `ApiResponse<TreatmentPlan>`. |
+| Posibles errores | `400` body invalido o descuento negativo, `401` token invalido, `404` plan inexistente o sin ownership, `500` error interno. |
+
+### DELETE `/api/treatment-plans/:id`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `DELETE` |
+| Descripcion | Cancela logicamente el plan: `status = CANCELLED` y asigna `rejected_at`. No borra fisicamente el registro. |
+| Params | `id`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | No aplica. |
+| Response body | `ApiResponse<TreatmentPlan>`. |
+| Posibles errores | `400` parametro invalido, `401` token invalido, `404` plan inexistente o sin ownership, `500` error interno. |
+
+### PATCH `/api/treatment-plans/:id/status`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `PATCH` |
+| Descripcion | Actualiza el estado del plan. Si el estado es `ACCEPTED`, asigna `accepted_at`; si es `CANCELLED`, asigna `rejected_at`. |
+| Params | `id`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | `UpdateTreatmentPlanStatusRequest`. |
+| Response body | `ApiResponse<TreatmentPlan>`. |
+| Posibles errores | `400` estado invalido, `401` token invalido, `404` plan inexistente o sin ownership, `500` error interno. |
+
+### POST `/api/treatment-plans/:id/items`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `POST` |
+| Descripcion | Agrega un item al plan en estado `PENDING` y recalcula totales del plan. |
+| Params | `id`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | `CreateTreatmentPlanItemRequest`. `name`, `quantity` y `unit_price` son obligatorios. |
+| Response body | `ApiResponse<{ item: TreatmentPlanItem; treatmentPlan: TreatmentPlan }>` con status HTTP `201`. |
+| Posibles errores | `400` body invalido, `401` token invalido, `404` plan/concepto inexistente o sin ownership, `500` error interno. |
+
+### PUT `/api/treatment-plans/:id/items/:itemId`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `PUT` |
+| Descripcion | Actualiza un item y recalcula totales del plan. |
+| Params | `id`: entero mayor a 0, `itemId`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | `UpdateTreatmentPlanItemRequest`. Todos los campos son opcionales, pero `name` no puede estar vacio si se envia. |
+| Response body | `ApiResponse<{ item: TreatmentPlanItem; treatmentPlan: TreatmentPlan }>` |
+| Posibles errores | `400` body invalido, `401` token invalido, `404` plan/item/concepto inexistente o sin ownership, `500` error interno. |
+
+### DELETE `/api/treatment-plans/:id/items/:itemId`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `DELETE` |
+| Descripcion | Elimina fisicamente el item y recalcula totales del plan. |
+| Params | `id`: entero mayor a 0, `itemId`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | No aplica. |
+| Response body | `ApiResponse<{ treatmentPlan: TreatmentPlan }>` |
+| Posibles errores | `400` parametro invalido, `401` token invalido, `404` plan o item inexistente/sin ownership, `500` error interno. |
+
+### PATCH `/api/treatment-plans/:id/items/:itemId/status`
+
+| Campo | Detalle |
+| --- | --- |
+| Metodo HTTP | `PATCH` |
+| Descripcion | Actualiza el estado de un item. Si el estado es `COMPLETED`, asigna `completed_at`. |
+| Params | `id`: entero mayor a 0, `itemId`: entero mayor a 0. |
+| Query params | No aplica. |
+| Request body | `UpdateTreatmentPlanItemStatusRequest`. |
+| Response body | `ApiResponse<TreatmentPlanItem>`. |
+| Posibles errores | `400` estado invalido, `401` token invalido, `404` plan o item inexistente/sin ownership, `500` error interno. |
+
+## Interfaces TypeScript sugeridas para Angular
+
+```ts
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T | null;
+  errors: unknown | null;
+}
+
+export type ISODateString = string;
+
+export interface TreatmentPlan {
+  id: number;
+  user_id: number;
+  patient_id: number;
+  title: string;
+  description: string | null;
+  diagnosis: string | null;
+  patient_complaint: string | null;
+  clinical_observations: string | null;
+  prognosis: string | null;
+  status: TreatmentPlanStatus;
+  estimated_start_date: ISODateString | null;
+  estimated_end_date: ISODateString | null;
+  accepted_at: ISODateString | null;
+  rejected_at: ISODateString | null;
+  acceptance_notes: string | null;
+  subtotal: number | string;
+  discount: number | string;
+  total: number | string;
+  created_at?: ISODateString;
+  updated_at?: ISODateString;
+  TreatmentPlanItems?: TreatmentPlanItem[];
+}
+
+export interface TreatmentPlanItem {
+  id: number;
+  treatment_plan_id: number;
+  user_concept_id: number | null;
+  name: string;
+  description: string | null;
+  tooth: string | null;
+  area: string | null;
+  quantity: number | string;
+  unit_price: number | string;
+  subtotal: number | string;
+  phase: string | null;
+  priority: TreatmentPlanItemPriority | null;
+  status: TreatmentPlanItemStatus;
+  notes: string | null;
+  sort_order: number;
+  completed_at: ISODateString | null;
+  created_at?: ISODateString;
+  updated_at?: ISODateString;
+}
+
+export interface CreateTreatmentPlanRequest {
+  title: string;
+  description?: string | null;
+  diagnosis?: string | null;
+  patient_complaint?: string | null;
+  clinical_observations?: string | null;
+  prognosis?: string | null;
+  estimated_start_date?: ISODateString | null;
+  estimated_end_date?: ISODateString | null;
+  acceptance_notes?: string | null;
+  discount?: number;
+}
+
+export interface UpdateTreatmentPlanRequest {
+  title?: string;
+  description?: string | null;
+  diagnosis?: string | null;
+  patient_complaint?: string | null;
+  clinical_observations?: string | null;
+  prognosis?: string | null;
+  estimated_start_date?: ISODateString | null;
+  estimated_end_date?: ISODateString | null;
+  acceptance_notes?: string | null;
+  discount?: number;
+}
+
+export interface UpdateTreatmentPlanStatusRequest {
+  status: TreatmentPlanStatus;
+  acceptance_notes?: string | null;
+}
+
+export interface CreateTreatmentPlanItemRequest {
+  user_concept_id?: number | null;
+  name: string;
+  description?: string | null;
+  tooth?: string | null;
+  area?: string | null;
+  quantity: number;
+  unit_price: number;
+  phase?: string | null;
+  priority?: TreatmentPlanItemPriority | null;
+  notes?: string | null;
+  sort_order?: number;
+}
+
+export interface UpdateTreatmentPlanItemRequest {
+  user_concept_id?: number | null;
+  name?: string;
+  description?: string | null;
+  tooth?: string | null;
+  area?: string | null;
+  quantity?: number;
+  unit_price?: number;
+  phase?: string | null;
+  priority?: TreatmentPlanItemPriority | null;
+  notes?: string | null;
+  sort_order?: number;
+}
+
+export interface UpdateTreatmentPlanItemStatusRequest {
+  status: TreatmentPlanItemStatus;
+}
+
+export interface TreatmentPlanItemMutationResponse {
+  item: TreatmentPlanItem;
+  treatmentPlan: TreatmentPlan;
+}
+
+export interface DeleteTreatmentPlanItemResponse {
+  treatmentPlan: TreatmentPlan;
+}
+```
+
+## Enums TypeScript
+
+```ts
+export enum TreatmentPlanStatus {
+  DRAFT = 'DRAFT',
+  PROPOSED = 'PROPOSED',
+  ACCEPTED = 'ACCEPTED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+}
+
+export enum TreatmentPlanItemStatus {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  IN_PROGRESS = 'IN_PROGRESS',
+  COMPLETED = 'COMPLETED',
+  CANCELLED = 'CANCELLED',
+}
+
+export enum TreatmentPlanItemPriority {
+  LOW = 'LOW',
+  MEDIUM = 'MEDIUM',
+  HIGH = 'HIGH',
+  URGENT = 'URGENT',
+}
+```
+
+## Labels sugeridos para UI
+
+```ts
+export const TREATMENT_PLAN_STATUS_LABELS: Record<TreatmentPlanStatus, string> = {
+  [TreatmentPlanStatus.DRAFT]: 'Borrador',
+  [TreatmentPlanStatus.PROPOSED]: 'Propuesto',
+  [TreatmentPlanStatus.ACCEPTED]: 'Aceptado',
+  [TreatmentPlanStatus.IN_PROGRESS]: 'En progreso',
+  [TreatmentPlanStatus.COMPLETED]: 'Completado',
+  [TreatmentPlanStatus.CANCELLED]: 'Cancelado',
+};
+
+export const TREATMENT_PLAN_ITEM_STATUS_LABELS: Record<TreatmentPlanItemStatus, string> = {
+  [TreatmentPlanItemStatus.PENDING]: 'Pendiente',
+  [TreatmentPlanItemStatus.APPROVED]: 'Aprobado',
+  [TreatmentPlanItemStatus.IN_PROGRESS]: 'En progreso',
+  [TreatmentPlanItemStatus.COMPLETED]: 'Completado',
+  [TreatmentPlanItemStatus.CANCELLED]: 'Cancelado',
+};
+
+export const TREATMENT_PLAN_ITEM_PRIORITY_LABELS: Record<TreatmentPlanItemPriority, string> = {
+  [TreatmentPlanItemPriority.LOW]: 'Baja',
+  [TreatmentPlanItemPriority.MEDIUM]: 'Media',
+  [TreatmentPlanItemPriority.HIGH]: 'Alta',
+  [TreatmentPlanItemPriority.URGENT]: 'Urgente',
+};
+```
+
+## Ejemplos de requests JSON
+
+### Crear plan
+
+```json
+{
+  "title": "Rehabilitacion integral",
+  "description": "Plan por etapas para restauracion funcional y estetica.",
+  "diagnosis": "Caries multiples y ausencias dentales",
+  "patient_complaint": "Dolor al masticar",
+  "clinical_observations": "Requiere control periodontal previo",
+  "prognosis": "Favorable con seguimiento",
+  "estimated_start_date": "2026-07-01",
+  "estimated_end_date": "2026-09-30",
+  "acceptance_notes": null,
+  "discount": 500
+}
+```
+
+### Actualizar estado del plan
+
+```json
+{
+  "status": "ACCEPTED",
+  "acceptance_notes": "Paciente acepta el plan completo."
+}
+```
+
+### Crear item
+
+```json
+{
+  "user_concept_id": 12,
+  "name": "Resina clase II",
+  "description": "Restauracion en molar inferior",
+  "tooth": "36",
+  "area": "Oclusal",
+  "quantity": 1,
+  "unit_price": 1200,
+  "phase": "Fase restaurativa",
+  "priority": "HIGH",
+  "notes": "Realizar despues de profilaxis",
+  "sort_order": 1
+}
+```
+
+### Actualizar estado de item
+
+```json
+{
+  "status": "COMPLETED"
+}
+```
+
+## Ejemplos de responses JSON
+
+### Plan creado
+
+```json
+{
+  "success": true,
+  "message": "Plan de tratamiento creado correctamente",
+  "data": {
+    "id": 25,
+    "user_id": 3,
+    "patient_id": 10,
+    "title": "Rehabilitacion integral",
+    "description": "Plan por etapas para restauracion funcional y estetica.",
+    "diagnosis": "Caries multiples y ausencias dentales",
+    "patient_complaint": "Dolor al masticar",
+    "clinical_observations": "Requiere control periodontal previo",
+    "prognosis": "Favorable con seguimiento",
+    "status": "DRAFT",
+    "estimated_start_date": "2026-07-01T00:00:00.000Z",
+    "estimated_end_date": "2026-09-30T00:00:00.000Z",
+    "accepted_at": null,
+    "rejected_at": null,
+    "acceptance_notes": null,
+    "subtotal": 0,
+    "discount": 500,
+    "total": -500,
+    "created_at": "2026-06-26T20:00:00.000Z",
+    "updated_at": "2026-06-26T20:00:00.000Z"
+  },
+  "errors": null
+}
+```
+
+### Detalle de plan con items
+
+```json
+{
+  "success": true,
+  "message": "Plan de tratamiento obtenido correctamente",
+  "data": {
+    "id": 25,
+    "user_id": 3,
+    "patient_id": 10,
+    "title": "Rehabilitacion integral",
+    "status": "ACCEPTED",
+    "subtotal": "1200.00",
+    "discount": "500.00",
+    "total": "700.00",
+    "TreatmentPlanItems": [
+      {
+        "id": 40,
+        "treatment_plan_id": 25,
+        "user_concept_id": 12,
+        "name": "Resina clase II",
+        "description": "Restauracion en molar inferior",
+        "tooth": "36",
+        "area": "Oclusal",
+        "quantity": "1.00",
+        "unit_price": "1200.00",
+        "subtotal": "1200.00",
+        "phase": "Fase restaurativa",
+        "priority": "HIGH",
+        "status": "PENDING",
+        "notes": "Realizar despues de profilaxis",
+        "sort_order": 1,
+        "completed_at": null
+      }
+    ]
+  },
+  "errors": null
+}
+```
+
+### Item agregado
+
+```json
+{
+  "success": true,
+  "message": "Item agregado al plan de tratamiento correctamente",
+  "data": {
+    "item": {
+      "id": 40,
+      "treatment_plan_id": 25,
+      "user_concept_id": 12,
+      "name": "Resina clase II",
+      "quantity": 1,
+      "unit_price": 1200,
+      "subtotal": 1200,
+      "status": "PENDING",
+      "priority": "HIGH",
+      "completed_at": null
+    },
+    "treatmentPlan": {
+      "id": 25,
+      "subtotal": 1200,
+      "discount": 500,
+      "total": 700,
+      "status": "DRAFT"
+    }
+  },
+  "errors": null
+}
+```
+
+### Error de ownership o recurso inexistente
+
+```json
+{
+  "success": false,
+  "message": "El plan de tratamiento no existe o no pertenece al usuario autenticado",
+  "data": null,
+  "errors": null
+}
+```
+
+## Reglas importantes para frontend
+
+- Los totales los calcula el backend. El frontend puede mostrar subtotales preliminares para UX, pero debe persistir y renderizar los valores devueltos por la API.
+- El frontend no debe asumir ownership ni filtrar por `user_id`. El backend resuelve el usuario desde el JWT y valida pertenencia.
+- Todos los endpoints requieren token JWT: `Authorization: Bearer <token>`.
+- Los pagos reales siguen en el modulo de pagos. No se debe registrar cobro, ingreso, deuda ni recibo desde Plan de Tratamiento.
+- El plan de tratamiento no representa un pago. Es una propuesta clinica/economica, no una transaccion financiera.
+- `DELETE /api/treatment-plans/:id` cancela el plan; no lo elimina fisicamente.
+- `DELETE /api/treatment-plans/:id/items/:itemId` elimina el item y devuelve el plan recalculado.
+- Las fechas pueden enviarse como `YYYY-MM-DD` o ISO 8601; la API responde normalmente como string ISO.
+- Los campos monetarios pueden llegar como `number` o `string` segun la serializacion de Sequelize/DECIMAL. En Angular conviene normalizarlos antes de formatear moneda.
+
+## Checklist de integracion para Angular
+
+- Crear modelos/interfaces del modulo en `treatment-plan.models.ts`.
+- Crear enums y labels compartidos para estados/prioridades.
+- Crear `TreatmentPlanService` con `HttpClient` y base path `/api`.
+- Agregar interceptor o helper para enviar `Authorization: Bearer <token>`.
+- Implementar listado por paciente: `GET /api/patients/:patientId/treatment-plans`.
+- Implementar detalle del plan: `GET /api/treatment-plans/:id`.
+- Implementar formularios de creacion/edicion usando `snake_case` en el payload.
+- No enviar `subtotal`, `total`, `user_id`, `patient_id`, `accepted_at`, `rejected_at` ni `completed_at` desde formularios.
+- Despues de crear, actualizar o borrar items, refrescar el plan con el `treatmentPlan` devuelto o recargar detalle.
+- Manejar errores estandar `ApiResponse` y tambien errores de validacion con propiedad `errors` de `express-validator`.
+- Convertir importes a numero antes de usar pipes o calculos visuales.
+- Usar labels de UI para no mostrar valores crudos como `IN_PROGRESS` al usuario.

--- a/docs/frontend-integration/treatment-plan-pagination-ui-context.md
+++ b/docs/frontend-integration/treatment-plan-pagination-ui-context.md
@@ -1,0 +1,78 @@
+# Treatment Plan Pagination UI Context
+
+## Endpoint actualizado
+
+`GET /patients/:patientId/treatment-plans`
+
+El listado de planes de tratamiento ahora responde con paginacion, siguiendo el mismo contrato usado por `evolution-note`, `patient` y `payment`.
+
+## Query params
+
+| Param | Tipo | Default | Descripcion |
+| --- | --- | --- | --- |
+| `page` | number | `1` | Pagina actual. Debe ser mayor a 0. |
+| `limit` | number | `10` | Cantidad de registros por pagina. Debe ser mayor a 0. |
+
+Ejemplo:
+
+```http
+GET /patients/123/treatment-plans?page=1&limit=10
+```
+
+## Nuevo formato de respuesta
+
+Antes, `data` era un array directo de planes:
+
+```json
+{
+  "success": true,
+  "message": "Planes de tratamiento obtenidos correctamente",
+  "data": []
+}
+```
+
+Ahora, `data` contiene metadata de paginacion y los planes vienen dentro de `results`:
+
+```json
+{
+  "success": true,
+  "message": "Planes de tratamiento obtenidos correctamente",
+  "data": {
+    "total": 25,
+    "page": 1,
+    "perPage": 10,
+    "totalPages": 3,
+    "results": []
+  },
+  "errors": null
+}
+```
+
+## Ajuste requerido en UI
+
+Actualizar el consumo del endpoint para leer la lista desde:
+
+```ts
+response.data
+```
+
+a:
+
+```ts
+response.data.results
+```
+
+La UI tambien puede usar:
+
+```ts
+response.data.total
+response.data.page
+response.data.perPage
+response.data.totalPages
+```
+
+para renderizar controles de paginacion.
+
+## Notas de compatibilidad
+
+Este cambio modifica el contrato del endpoint de listado. Las pantallas que esperaban un array directo deben adaptarse al nuevo objeto paginado.

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,38 +102,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/architect/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular-devkit/architect/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/build-angular": {
       "version": "19.2.2",
       "resolved": "https://registry.npmjs.org/@angular-devkit/build-angular/-/build-angular-19.2.2.tgz",
@@ -288,23 +256,6 @@
         }
       }
     },
-    "node_modules/@angular-devkit/build-angular/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
     "node_modules/@angular-devkit/build-angular/node_modules/postcss": {
       "version": "8.5.2",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.2.tgz",
@@ -332,21 +283,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
-      }
-    },
-    "node_modules/@angular-devkit/build-angular/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular-devkit/build-angular/node_modules/semver": {
@@ -427,38 +363,6 @@
         "chokidar": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular-devkit/schematics/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/animations": {
@@ -724,38 +628,6 @@
         "chokidar": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@angular/cli/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@angular/cli/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@angular/cli/node_modules/semver": {
@@ -5200,38 +5072,6 @@
         "chokidar": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "readdirp": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 14.16.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      }
-    },
-    "node_modules/@schematics/angular/node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
-      "dev": true,
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">= 14.18.0"
-      },
-      "funding": {
-        "type": "individual",
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@sigstore/bundle": {

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -12,6 +12,7 @@ import { EvolutionNotesComponent } from './features/patients/evolution-notes/evo
 import { PatientPaymentsComponent } from './features/patients/patient-payments/patient-payments.component';
 import { InformedConsentsComponent } from './features/patients/informed-consents/informed-consents.component';
 import { OdontogramComponent } from './features/patients/odontogram/odontogram.component';
+import { PatientTreatmentPlansComponent } from './features/patients/patient-treatment-plans/patient-treatment-plans.component';
 import { AgendaComponent } from './features/dentist/agenda/agenda.component';
 import { SettingsComponent } from './features/settings/components/settings/settings.component';
 import { ResetPasswordComponent } from './features/auth/components/reset-password/reset-password.component';
@@ -31,6 +32,7 @@ export const routes: Routes = [
   { path: 'evolution-notes', component: EvolutionNotesComponent, canActivate: [AuthGuard] },
   { path: 'patient-payment', component: PatientPaymentsComponent, canActivate: [AuthGuard] },
   { path: 'informed-consents', component: InformedConsentsComponent, canActivate: [AuthGuard] },
+  { path: 'patient-treatment-plans', component: PatientTreatmentPlansComponent, canActivate: [AuthGuard] },
   { path: 'odontogram', component: OdontogramComponent, canActivate: [AuthGuard] },
   { path: 'schedule', component: AgendaComponent, canActivate: [AuthGuard] },
   { path: 'settings', component: SettingsComponent, canActivate: [AuthGuard] }

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -13,6 +13,7 @@ import { PatientPaymentsComponent } from './features/patients/patient-payments/p
 import { InformedConsentsComponent } from './features/patients/informed-consents/informed-consents.component';
 import { OdontogramComponent } from './features/patients/odontogram/odontogram.component';
 import { PatientTreatmentPlansComponent } from './features/patients/patient-treatment-plans/patient-treatment-plans.component';
+import { TreatmentPlanDetailComponent } from './features/patients/treatment-plan-detail/treatment-plan-detail.component';
 import { AgendaComponent } from './features/dentist/agenda/agenda.component';
 import { SettingsComponent } from './features/settings/components/settings/settings.component';
 import { ResetPasswordComponent } from './features/auth/components/reset-password/reset-password.component';
@@ -33,6 +34,7 @@ export const routes: Routes = [
   { path: 'patient-payment', component: PatientPaymentsComponent, canActivate: [AuthGuard] },
   { path: 'informed-consents', component: InformedConsentsComponent, canActivate: [AuthGuard] },
   { path: 'patient-treatment-plans', component: PatientTreatmentPlansComponent, canActivate: [AuthGuard] },
+  { path: 'treatment-plan-detail', component: TreatmentPlanDetailComponent, canActivate: [AuthGuard] },
   { path: 'odontogram', component: OdontogramComponent, canActivate: [AuthGuard] },
   { path: 'schedule', component: AgendaComponent, canActivate: [AuthGuard] },
   { path: 'settings', component: SettingsComponent, canActivate: [AuthGuard] }

--- a/src/app/core/models/treatment-plan.model.ts
+++ b/src/app/core/models/treatment-plan.model.ts
@@ -26,6 +26,30 @@ export enum TreatmentPlanItemPriority {
     URGENT = 'URGENT',
 }
 
+export const TREATMENT_PLAN_STATUS_LABELS: Record<TreatmentPlanStatus, string> = {
+    [TreatmentPlanStatus.DRAFT]: 'Borrador',
+    [TreatmentPlanStatus.PROPOSED]: 'Propuesto',
+    [TreatmentPlanStatus.ACCEPTED]: 'Aceptado',
+    [TreatmentPlanStatus.IN_PROGRESS]: 'En progreso',
+    [TreatmentPlanStatus.COMPLETED]: 'Completado',
+    [TreatmentPlanStatus.CANCELLED]: 'Cancelado',
+};
+
+export const TREATMENT_PLAN_ITEM_STATUS_LABELS: Record<TreatmentPlanItemStatus, string> = {
+    [TreatmentPlanItemStatus.PENDING]: 'Pendiente',
+    [TreatmentPlanItemStatus.APPROVED]: 'Aprobado',
+    [TreatmentPlanItemStatus.IN_PROGRESS]: 'En progreso',
+    [TreatmentPlanItemStatus.COMPLETED]: 'Completado',
+    [TreatmentPlanItemStatus.CANCELLED]: 'Cancelado',
+};
+
+export const TREATMENT_PLAN_ITEM_PRIORITY_LABELS: Record<TreatmentPlanItemPriority, string> = {
+    [TreatmentPlanItemPriority.LOW]: 'Baja',
+    [TreatmentPlanItemPriority.MEDIUM]: 'Media',
+    [TreatmentPlanItemPriority.HIGH]: 'Alta',
+    [TreatmentPlanItemPriority.URGENT]: 'Urgente',
+};
+
 // La API documentada responde en snake_case. Si la UI usa camelCase, mapear antes de renderizar.
 export interface TreatmentPlan {
     id: number;

--- a/src/app/core/models/treatment-plan.model.ts
+++ b/src/app/core/models/treatment-plan.model.ts
@@ -1,0 +1,147 @@
+export type ISODateString = string;
+
+export enum TreatmentPlanStatus {
+    DRAFT = 'DRAFT',
+    PROPOSED = 'PROPOSED',
+    ACCEPTED = 'ACCEPTED',
+    IN_PROGRESS = 'IN_PROGRESS',
+    COMPLETED = 'COMPLETED',
+    CANCELLED = 'CANCELLED',
+}
+
+export enum TreatmentPlanItemStatus {
+    PENDING = 'PENDING',
+    APPROVED = 'APPROVED',
+    IN_PROGRESS = 'IN_PROGRESS',
+    COMPLETED = 'COMPLETED',
+    CANCELLED = 'CANCELLED',
+}
+
+export enum TreatmentPlanItemPriority {
+    LOW = 'LOW',
+    MEDIUM = 'MEDIUM',
+    HIGH = 'HIGH',
+    URGENT = 'URGENT',
+}
+
+// La API documentada responde en snake_case. Si la UI usa camelCase, mapear antes de renderizar.
+export interface TreatmentPlan {
+    id: number;
+    user_id: number;
+    patient_id: number;
+    title: string;
+    description: string | null;
+    diagnosis: string | null;
+    patient_complaint: string | null;
+    clinical_observations: string | null;
+    prognosis: string | null;
+    status: TreatmentPlanStatus;
+    estimated_start_date: ISODateString | null;
+    estimated_end_date: ISODateString | null;
+    accepted_at: ISODateString | null;
+    rejected_at: ISODateString | null;
+    acceptance_notes: string | null;
+    subtotal: number | string;
+    discount: number | string;
+    total: number | string;
+    created_at?: ISODateString;
+    updated_at?: ISODateString;
+    TreatmentPlanItems?: TreatmentPlanItem[];
+}
+
+export interface TreatmentPlanItem {
+    id: number;
+    treatment_plan_id: number;
+    user_concept_id: number | null;
+    name: string;
+    description: string | null;
+    tooth: string | null;
+    area: string | null;
+    quantity: number | string;
+    unit_price: number | string;
+    subtotal: number | string;
+    phase: string | null;
+    priority: TreatmentPlanItemPriority | null;
+    status: TreatmentPlanItemStatus;
+    notes: string | null;
+    sort_order: number;
+    completed_at: ISODateString | null;
+    created_at?: ISODateString;
+    updated_at?: ISODateString;
+}
+
+export interface CreateTreatmentPlanRequest {
+    title: string;
+    description?: string | null;
+    diagnosis?: string | null;
+    patient_complaint?: string | null;
+    clinical_observations?: string | null;
+    prognosis?: string | null;
+    estimated_start_date?: ISODateString | null;
+    estimated_end_date?: ISODateString | null;
+    acceptance_notes?: string | null;
+    discount?: number;
+}
+
+export interface UpdateTreatmentPlanRequest {
+    title?: string;
+    description?: string | null;
+    diagnosis?: string | null;
+    patient_complaint?: string | null;
+    clinical_observations?: string | null;
+    prognosis?: string | null;
+    estimated_start_date?: ISODateString | null;
+    estimated_end_date?: ISODateString | null;
+    acceptance_notes?: string | null;
+    discount?: number;
+}
+
+export interface UpdateTreatmentPlanStatusRequest {
+    status: TreatmentPlanStatus;
+    acceptance_notes?: string | null;
+}
+
+export interface CreateTreatmentPlanItemRequest {
+    user_concept_id?: number | null;
+    name: string;
+    description?: string | null;
+    tooth?: string | null;
+    area?: string | null;
+    quantity: number;
+    unit_price: number;
+    phase?: string | null;
+    priority?: TreatmentPlanItemPriority | null;
+    notes?: string | null;
+    sort_order?: number;
+}
+
+export interface UpdateTreatmentPlanItemRequest {
+    user_concept_id?: number | null;
+    name?: string;
+    description?: string | null;
+    tooth?: string | null;
+    area?: string | null;
+    quantity?: number;
+    unit_price?: number;
+    phase?: string | null;
+    priority?: TreatmentPlanItemPriority | null;
+    notes?: string | null;
+    sort_order?: number;
+}
+
+export interface UpdateTreatmentPlanItemStatusRequest {
+    status: TreatmentPlanItemStatus;
+}
+
+export type TreatmentPlanListResponse = TreatmentPlan[];
+
+export type TreatmentPlanDetailResponse = TreatmentPlan;
+
+export interface TreatmentPlanItemMutationResponse {
+    item: TreatmentPlanItem;
+    treatmentPlan: TreatmentPlan;
+}
+
+export interface DeleteTreatmentPlanItemResponse {
+    treatmentPlan: TreatmentPlan;
+}

--- a/src/app/core/models/treatment-plan.model.ts
+++ b/src/app/core/models/treatment-plan.model.ts
@@ -1,3 +1,5 @@
+import { PaginatedResponse } from './api-response.model';
+
 export type ISODateString = string;
 
 export enum TreatmentPlanStatus {
@@ -133,7 +135,7 @@ export interface UpdateTreatmentPlanItemStatusRequest {
     status: TreatmentPlanItemStatus;
 }
 
-export type TreatmentPlanListResponse = TreatmentPlan[];
+export type TreatmentPlanListResponse = PaginatedResponse<TreatmentPlan>;
 
 export type TreatmentPlanDetailResponse = TreatmentPlan;
 

--- a/src/app/core/services/treatment-plan.service.ts
+++ b/src/app/core/services/treatment-plan.service.ts
@@ -1,0 +1,66 @@
+import { Injectable } from '@angular/core';
+import { environment } from '../../../environments/environment';
+import { ApiService } from './api.service';
+import {
+    CreateTreatmentPlanItemRequest,
+    CreateTreatmentPlanRequest,
+    DeleteTreatmentPlanItemResponse,
+    TreatmentPlan,
+    TreatmentPlanDetailResponse,
+    TreatmentPlanItem,
+    TreatmentPlanItemMutationResponse,
+    TreatmentPlanListResponse,
+    UpdateTreatmentPlanItemRequest,
+    UpdateTreatmentPlanItemStatusRequest,
+    UpdateTreatmentPlanRequest,
+    UpdateTreatmentPlanStatusRequest,
+} from '../models/treatment-plan.model';
+
+const API_PATH = environment.API_URL;
+
+@Injectable({
+    providedIn: 'root'
+})
+export class TreatmentPlanService {
+    constructor(private api: ApiService) { }
+
+    listTreatmentPlansByPatient(patientId: number) {
+        return this.api.get<TreatmentPlanListResponse>(`${API_PATH}/patients/${patientId}/treatment-plans`);
+    }
+
+    createTreatmentPlan(patientId: number, treatmentPlan: CreateTreatmentPlanRequest) {
+        return this.api.post<TreatmentPlan>(`${API_PATH}/patients/${patientId}/treatment-plans`, treatmentPlan);
+    }
+
+    getTreatmentPlanDetail(id: number) {
+        return this.api.get<TreatmentPlanDetailResponse>(`${API_PATH}/treatment-plans/${id}`);
+    }
+
+    updateTreatmentPlan(id: number, treatmentPlan: UpdateTreatmentPlanRequest) {
+        return this.api.put<TreatmentPlan>(`${API_PATH}/treatment-plans/${id}`, treatmentPlan);
+    }
+
+    cancelTreatmentPlan(id: number) {
+        return this.api.delete<TreatmentPlan>(`${API_PATH}/treatment-plans/${id}`);
+    }
+
+    updateTreatmentPlanStatus(id: number, status: UpdateTreatmentPlanStatusRequest) {
+        return this.api.patch<TreatmentPlan>(`${API_PATH}/treatment-plans/${id}/status`, status);
+    }
+
+    createTreatmentPlanItem(id: number, item: CreateTreatmentPlanItemRequest) {
+        return this.api.post<TreatmentPlanItemMutationResponse>(`${API_PATH}/treatment-plans/${id}/items`, item);
+    }
+
+    updateTreatmentPlanItem(id: number, itemId: number, item: UpdateTreatmentPlanItemRequest) {
+        return this.api.put<TreatmentPlanItemMutationResponse>(`${API_PATH}/treatment-plans/${id}/items/${itemId}`, item);
+    }
+
+    deleteTreatmentPlanItem(id: number, itemId: number) {
+        return this.api.delete<DeleteTreatmentPlanItemResponse>(`${API_PATH}/treatment-plans/${id}/items/${itemId}`);
+    }
+
+    updateTreatmentPlanItemStatus(id: number, itemId: number, status: UpdateTreatmentPlanItemStatusRequest) {
+        return this.api.patch<TreatmentPlanItem>(`${API_PATH}/treatment-plans/${id}/items/${itemId}/status`, status);
+    }
+}

--- a/src/app/core/services/treatment-plan.service.ts
+++ b/src/app/core/services/treatment-plan.service.ts
@@ -24,8 +24,10 @@ const API_PATH = environment.API_URL;
 export class TreatmentPlanService {
     constructor(private api: ApiService) { }
 
-    listTreatmentPlansByPatient(patientId: number) {
-        return this.api.get<TreatmentPlanListResponse>(`${API_PATH}/patients/${patientId}/treatment-plans`);
+    listTreatmentPlansByPatient(patientId: number, page = 1, limit = 10) {
+        return this.api.get<TreatmentPlanListResponse>(
+            `${API_PATH}/patients/${patientId}/treatment-plans?page=${page}&limit=${limit}`
+        );
     }
 
     createTreatmentPlan(patientId: number, treatmentPlan: CreateTreatmentPlanRequest) {

--- a/src/app/features/patients/patient-dashboard/patient-dashboard.component.html
+++ b/src/app/features/patients/patient-dashboard/patient-dashboard.component.html
@@ -94,7 +94,7 @@
         </div>
     </div>
     <div class="row menu_row">
-        <div class="col-12">
+        <div class="col-6">
             <div class="custom_card_header">
                 <div class="custom_icon">
                     <mat-icon svgIcon="recetas" class="dashboard_agenda_icon"></mat-icon>
@@ -105,9 +105,7 @@
                 </div>
             </div>
         </div>
-    </div>
-    <div class="row menu_row">
-        <div class="col-12">
+        <div class="col-6">
             <div class="custom_card_header">
                 <div class="custom_icon">
                     <mat-icon svgIcon="finanzas" class="dashboard_agenda_icon"></mat-icon>

--- a/src/app/features/patients/patient-dashboard/patient-dashboard.component.html
+++ b/src/app/features/patients/patient-dashboard/patient-dashboard.component.html
@@ -97,6 +97,19 @@
         <div class="col-12">
             <div class="custom_card_header">
                 <div class="custom_icon">
+                    <mat-icon svgIcon="recetas" class="dashboard_agenda_icon"></mat-icon>
+                </div>
+                <div class="custom_title" (click)="goToTreatmentPlans()">
+                    <p class="custom_card_title">Planes de Tratamiento</p>
+                    <span class="custom-card-subtitle">Consulta las propuestas clinicas y economicas del paciente</span>
+                </div>
+            </div>
+        </div>
+    </div>
+    <div class="row menu_row">
+        <div class="col-12">
+            <div class="custom_card_header">
+                <div class="custom_icon">
                     <mat-icon svgIcon="finanzas" class="dashboard_agenda_icon"></mat-icon>
                 </div>
                 <div class="custom_title" (click)="goToHistorialPagos()">

--- a/src/app/features/patients/patient-dashboard/patient-dashboard.component.ts
+++ b/src/app/features/patients/patient-dashboard/patient-dashboard.component.ts
@@ -122,6 +122,10 @@ export class PatientDashboardComponent {
     this.router.navigate(['patient-payment', { id: this.pacienteId }])
   }
 
+  goToTreatmentPlans() {
+    this.router.navigate(['patient-treatment-plans', { id: this.pacienteId }])
+  }
+
   goToOdontograma() {
     this.router.navigate(['odontogram', { id: this.pacienteId }])
   }

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
@@ -1,0 +1,86 @@
+<app-nav-bar></app-nav-bar>
+<ngx-spinner type="ball-newton-cradle"></ngx-spinner>
+
+<div class="container">
+    <div class="row navigation_row">
+        <div class="col-12">
+            <span class="pacientes_navigation">Inicio > Pacientes > Planes de Tratamiento</span>
+        </div>
+    </div>
+    <div class="row pacientes_header_row">
+        <div class="col-12">
+            <div class="title_container">
+                <mat-icon svgIcon="recetas" class="dashboard_agenda_icon"></mat-icon>
+                <span class="pacientes_title">Planes de Tratamiento</span>
+            </div>
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            @if (dataSource && dataSource.length > 0) {
+            <table mat-table [dataSource]="dataSource" class="mat-elevation-z0 info-table">
+                <ng-container matColumnDef="title">
+                    <th mat-header-cell *matHeaderCellDef class="title-header-column"> Plan </th>
+                    <td mat-cell *matCellDef="let element" class="title-content-column"> {{element.title}} </td>
+                </ng-container>
+
+                <ng-container matColumnDef="status">
+                    <th mat-header-cell *matHeaderCellDef class="status-header-column"> Estado </th>
+                    <td mat-cell *matCellDef="let element" class="status-content-column">
+                        <span class="status-badge" [ngClass]="getStatusClass(element.status)">
+                            {{getStatusLabel(element.status)}}
+                        </span>
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="startDate">
+                    <th mat-header-cell *matHeaderCellDef class="date-header-column"> Inicio estimado </th>
+                    <td mat-cell *matCellDef="let element" class="date-content-column">
+                        {{element.estimated_start_date ? (element.estimated_start_date | date) : '--'}}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="endDate">
+                    <th mat-header-cell *matHeaderCellDef class="date-header-column"> Fin estimado </th>
+                    <td mat-cell *matCellDef="let element" class="date-content-column">
+                        {{element.estimated_end_date ? (element.estimated_end_date | date) : '--'}}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="total">
+                    <th mat-header-cell *matHeaderCellDef class="total-header-column"> Total </th>
+                    <td mat-cell *matCellDef="let element" class="total-content-column">
+                        {{toCurrencyValue(element.total) | currency:'MXN':'symbol':'1.2-2'}}
+                    </td>
+                </ng-container>
+
+                <ng-container matColumnDef="createdAt">
+                    <th mat-header-cell *matHeaderCellDef class="date-header-column"> Creacion </th>
+                    <td mat-cell *matCellDef="let element" class="date-content-column">
+                        {{element.created_at ? (element.created_at | date) : '--'}}
+                    </td>
+                </ng-container>
+
+                <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+                <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+            </table>
+            }
+            @if (!dataSource || dataSource.length === 0) {
+            <app-no-data-found [title]="'Este paciente no tiene planes de tratamiento'"
+                [message]="'Cuando existan planes de tratamiento, apareceran en este listado.'">
+            </app-no-data-found>
+            }
+        </div>
+    </div>
+
+    <div class="row">
+        <div class="col-12">
+            @if (dataSource && dataSource.length > 0) {
+            <mat-paginator (page)="handlePageEvent($event)" [length]="length" [pageSize]="pageSize"
+                [pageIndex]="pageIndex" [pageSizeOptions]="[10, 25, 50, 100]" class="custom-paginator">
+            </mat-paginator>
+            }
+        </div>
+    </div>
+</div>

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
@@ -8,10 +8,15 @@
         </div>
     </div>
     <div class="row pacientes_header_row">
-        <div class="col-12">
+        <div class="col-6">
             <div class="title_container">
                 <mat-icon svgIcon="recetas" class="dashboard_agenda_icon"></mat-icon>
                 <span class="pacientes_title">Planes de Tratamiento</span>
+            </div>
+        </div>
+        <div class="col-6">
+            <div class="nuevo_paciente_button_container">
+                <button mat-fab extended class="logout-navbar-button" (click)="openTreatmentPlanDialog()">Nuevo plan</button>
             </div>
         </div>
     </div>

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
@@ -67,6 +67,14 @@
                     </td>
                 </ng-container>
 
+                <ng-container matColumnDef="actions">
+                    <th mat-header-cell *matHeaderCellDef class="actions-header-column"> Acciones </th>
+                    <td mat-cell *matCellDef="let element" class="actions-content-column">
+                        <mat-icon class="dashboard_logout_icon" fontIcon="visibility" matTooltip="Ver detalle"
+                            (click)="goToTreatmentPlanDetail(element.id)"></mat-icon>
+                    </td>
+                </ng-container>
+
                 <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
                 <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
             </table>

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
@@ -72,6 +72,8 @@
                     <td mat-cell *matCellDef="let element" class="actions-content-column">
                         <mat-icon class="dashboard_logout_icon" fontIcon="visibility" matTooltip="Ver detalle"
                             (click)="goToTreatmentPlanDetail(element.id)"></mat-icon>
+                        <mat-icon class="dashboard_logout_icon delete-action-icon" fontIcon="delete"
+                            matTooltip="Eliminar plan" (click)="confirmDeleteTreatmentPlan(element)"></mat-icon>
                     </td>
                 </ng-container>
 

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.html
@@ -21,6 +21,21 @@
         </div>
     </div>
 
+    <div class="row filters_row">
+        <div class="col-12">
+            <mat-form-field class="status-filter" appearance="outline">
+                <mat-label>Estado</mat-label>
+                <mat-select [value]="selectedStatusFilter" (selectionChange)="setStatusFilter($event.value)">
+                    <mat-option value="ACTIVE">Activos</mat-option>
+                    <mat-option value="ALL">Todos</mat-option>
+                    @for (status of statusOptions; track status) {
+                    <mat-option [value]="status">{{getStatusLabel(status)}}</mat-option>
+                    }
+                </mat-select>
+            </mat-form-field>
+        </div>
+    </div>
+
     <div class="row">
         <div class="col-12">
             @if (dataSource && dataSource.length > 0) {
@@ -82,8 +97,9 @@
             </table>
             }
             @if (!dataSource || dataSource.length === 0) {
-            <app-no-data-found [title]="'Este paciente no tiene planes de tratamiento'"
-                [message]="'Cuando existan planes de tratamiento, apareceran en este listado.'">
+            <app-no-data-found
+                [title]="allTreatmentPlans.length > 0 ? 'No hay planes con este estado' : 'Este paciente no tiene planes de tratamiento'"
+                [message]="allTreatmentPlans.length > 0 ? 'Cambia el filtro para consultar otros planes de tratamiento.' : 'Cuando existan planes de tratamiento, apareceran en este listado.'">
             </app-no-data-found>
             }
         </div>
@@ -91,7 +107,7 @@
 
     <div class="row">
         <div class="col-12">
-            @if (dataSource && dataSource.length > 0) {
+            @if (length > 0) {
             <mat-paginator (page)="handlePageEvent($event)" [length]="length" [pageSize]="pageSize"
                 [pageIndex]="pageIndex" [pageSizeOptions]="[10, 25, 50, 100]" class="custom-paginator">
             </mat-paginator>

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
@@ -98,7 +98,7 @@ table {
 }
 
 .actions-header-column {
-  width: 8%;
+  width: 10%;
 }
 
 .title-content-column {
@@ -131,6 +131,14 @@ table {
   height: auto;
   margin: 10px;
   cursor: pointer;
+}
+
+.actions-content-column {
+  white-space: nowrap;
+}
+
+.delete-action-icon {
+  color: #EB5757;
 }
 
 .status-badge {

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
@@ -1,0 +1,156 @@
+@use "../../../../vars.scss" as *;
+
+.logout-navbar-button {
+  height: 30px;
+  color: #fff;
+  background-color: $second--blue;
+  letter-spacing: 0.02em;
+  box-shadow: none !important;
+}
+
+.pacientes_header_row {
+  margin-top: 15px;
+  margin-bottom: 20px;
+}
+
+.navigation_row {
+  margin-top: 15px;
+  margin-bottom: 30px;
+}
+
+.pacientes_title {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 26px;
+  line-height: 30px;
+  letter-spacing: 0.01em;
+  color: $primary--blue;
+}
+
+.dashboard_agenda_icon {
+  width: 50px;
+  height: auto;
+  margin-right: 20px;
+}
+
+.title_container {
+  display: flex;
+  align-items: center;
+}
+
+.pacientes_navigation {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 21px;
+  display: flex;
+  align-items: center;
+  letter-spacing: 0.02em;
+  color: $primary--blue;
+}
+
+.info-table {
+  background-color: #fff;
+}
+
+.mat-mdc-row .mat-mdc-cell {
+  border: 1px solid #C0D9FF;
+}
+
+.mat-mdc-header-row .mat-mdc-header-cell {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16px;
+  letter-spacing: 0.01em;
+  color: $main--blue;
+  border: 2px solid #C0D9FF;
+}
+
+table {
+  width: 100%;
+}
+
+.title-header-column {
+  width: 34%;
+}
+
+.status-header-column {
+  width: 14%;
+}
+
+.date-header-column {
+  width: 13%;
+}
+
+.total-header-column {
+  width: 13%;
+}
+
+.title-content-column {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: #7A7A7A;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  max-width: 260px;
+}
+
+.status-content-column,
+.date-content-column,
+.total-content-column {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: $main--blue;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 92px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 16px;
+  color: $main--blue;
+  background-color: #EAF2FF;
+}
+
+.status-accepted,
+.status-completed {
+  color: #219653;
+  background-color: #E9F8EF;
+}
+
+.status-in-progress,
+.status-proposed {
+  color: #407DDA;
+  background-color: #EAF2FF;
+}
+
+.status-cancelled {
+  color: #EB5757;
+  background-color: #FDECEC;
+}
+
+.status-draft {
+  color: #7A7A7A;
+  background-color: #F2F2F2;
+}
+
+.custom-paginator {
+  color: $main--blue;
+  margin-bottom: 35px;
+  background-color: #fff;
+}

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
@@ -46,6 +46,14 @@
   justify-content: flex-end;
 }
 
+.filters_row {
+  margin-bottom: 16px;
+}
+
+.status-filter {
+  width: 220px;
+}
+
 .pacientes_navigation {
   font-family: 'Roboto';
   font-style: normal;

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
@@ -97,6 +97,10 @@ table {
   width: 13%;
 }
 
+.actions-header-column {
+  width: 8%;
+}
+
 .title-content-column {
   font-family: 'Roboto';
   font-style: normal;
@@ -112,13 +116,21 @@ table {
 
 .status-content-column,
 .date-content-column,
-.total-content-column {
+.total-content-column,
+.actions-content-column {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
   font-size: 14px;
   line-height: 20px;
   color: $main--blue;
+}
+
+.dashboard_logout_icon {
+  width: 20px;
+  height: auto;
+  margin: 10px;
+  cursor: pointer;
 }
 
 .status-badge {

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.scss
@@ -39,6 +39,13 @@
   align-items: center;
 }
 
+.nuevo_paciente_button_container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
 .pacientes_navigation {
   font-family: 'Roboto';
   font-style: normal;

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.spec.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PatientTreatmentPlansComponent } from './patient-treatment-plans.component';
+
+describe('PatientTreatmentPlansComponent', () => {
+  let component: PatientTreatmentPlansComponent;
+  let fixture: ComponentFixture<PatientTreatmentPlansComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PatientTreatmentPlansComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(PatientTreatmentPlansComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
@@ -2,8 +2,10 @@ import { CommonModule } from '@angular/common';
 import { Component, ElementRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { MatTooltipModule } from '@angular/material/tooltip';
@@ -17,6 +19,8 @@ import { NoDataFoundComponent } from '../../../shared/components/no-data-found/n
 import { ConfirmDialogComponent } from '../../../shared/dialogs/confirm-dialog/confirm-dialog.component';
 import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
 
+type TreatmentPlanStatusFilter = TreatmentPlanStatus | 'ACTIVE' | 'ALL';
+
 @Component({
   selector: 'app-patient-treatment-plans',
   imports: [
@@ -24,8 +28,10 @@ import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatm
     NavBarComponent,
     MatButtonModule,
     MatDialogModule,
+    MatFormFieldModule,
     MatIconModule,
     MatPaginatorModule,
+    MatSelectModule,
     MatTableModule,
     MatTooltipModule,
     NgxSpinnerModule,
@@ -36,14 +42,18 @@ import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatm
 })
 export class PatientTreatmentPlansComponent {
   displayedColumns: string[] = ['title', 'status', 'startDate', 'endDate', 'total', 'createdAt', 'actions'];
+  allTreatmentPlans: TreatmentPlan[] = [];
   dataSource: TreatmentPlan[] = [];
   selectedPatientId = 0;
   length = 0;
   pageIndex = 0;
   pageSize = 10;
   pageEvent: PageEvent = new PageEvent();
+  selectedStatusFilter: TreatmentPlanStatusFilter = 'ACTIVE';
 
   readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
+  readonly statusOptions = Object.values(TreatmentPlanStatus);
+  private readonly treatmentPlansFetchLimit = 1000;
 
   constructor(
     private route: ActivatedRoute,
@@ -75,12 +85,11 @@ export class PatientTreatmentPlansComponent {
 
   loadTreatmentPlans(page: number = 1): void {
     this.spinner.show();
-    this.treatmentPlanService.listTreatmentPlansByPatient(this.selectedPatientId, page, this.pageSize).subscribe({
+    this.treatmentPlanService.listTreatmentPlansByPatient(this.selectedPatientId, 1, this.treatmentPlansFetchLimit).subscribe({
       next: response => {
-        this.dataSource = response.data?.results ?? [];
-        this.length = response.data?.total ?? 0;
-        this.pageIndex = (response.data?.page ?? 1) - 1;
-        this.pageSize = response.data?.perPage ?? this.pageSize;
+        this.allTreatmentPlans = response.data?.results ?? [];
+        this.pageIndex = Math.max(page - 1, 0);
+        this.applyStatusFilter();
         this.spinner.hide();
       },
       error: error => {
@@ -92,10 +101,15 @@ export class PatientTreatmentPlansComponent {
 
   handlePageEvent(e: PageEvent): void {
     this.pageEvent = e;
-    this.length = e.length;
     this.pageSize = e.pageSize;
     this.pageIndex = e.pageIndex;
-    this.loadTreatmentPlans(this.pageIndex + 1);
+    this.updateDisplayedTreatmentPlans();
+  }
+
+  setStatusFilter(status: TreatmentPlanStatusFilter): void {
+    this.selectedStatusFilter = status;
+    this.pageIndex = 0;
+    this.applyStatusFilter();
   }
 
   openTreatmentPlanDialog(): void {
@@ -191,5 +205,34 @@ export class PatientTreatmentPlansComponent {
       ?? error?.error?.message
       ?? error?.message
       ?? 'Ocurrio un problema al procesar tu solicitud';
+  }
+
+  private applyStatusFilter(): void {
+    const filteredTreatmentPlans = this.getFilteredTreatmentPlans();
+    this.length = filteredTreatmentPlans.length;
+
+    if (this.pageIndex > 0 && this.pageIndex * this.pageSize >= this.length) {
+      this.pageIndex = Math.max(Math.ceil(this.length / this.pageSize) - 1, 0);
+    }
+
+    this.updateDisplayedTreatmentPlans(filteredTreatmentPlans);
+  }
+
+  private updateDisplayedTreatmentPlans(filteredTreatmentPlans = this.getFilteredTreatmentPlans()): void {
+    const start = this.pageIndex * this.pageSize;
+    const end = start + this.pageSize;
+    this.dataSource = filteredTreatmentPlans.slice(start, end);
+  }
+
+  private getFilteredTreatmentPlans(): TreatmentPlan[] {
+    if (this.selectedStatusFilter === 'ALL') {
+      return this.allTreatmentPlans;
+    }
+
+    if (this.selectedStatusFilter === 'ACTIVE') {
+      return this.allTreatmentPlans.filter(treatmentPlan => treatmentPlan.status !== TreatmentPlanStatus.CANCELLED);
+    }
+
+    return this.allTreatmentPlans.filter(treatmentPlan => treatmentPlan.status === this.selectedStatusFilter);
   }
 }

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
@@ -6,10 +6,11 @@ import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { DomSanitizer } from '@angular/platform-browser';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { NgxSpinnerModule, NgxSpinnerService } from 'ngx-spinner';
-import { CreateTreatmentPlanRequest, TreatmentPlan, TreatmentPlanStatus } from '../../../core/models/treatment-plan.model';
+import { CreateTreatmentPlanRequest, TREATMENT_PLAN_STATUS_LABELS, TreatmentPlan, TreatmentPlanStatus } from '../../../core/models/treatment-plan.model';
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
 import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
 import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
@@ -25,6 +26,7 @@ import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatm
     MatIconModule,
     MatPaginatorModule,
     MatTableModule,
+    MatTooltipModule,
     NgxSpinnerModule,
     NoDataFoundComponent
   ],
@@ -32,7 +34,7 @@ import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatm
   styleUrl: './patient-treatment-plans.component.scss'
 })
 export class PatientTreatmentPlansComponent {
-  displayedColumns: string[] = ['title', 'status', 'startDate', 'endDate', 'total', 'createdAt'];
+  displayedColumns: string[] = ['title', 'status', 'startDate', 'endDate', 'total', 'createdAt', 'actions'];
   dataSource: TreatmentPlan[] = [];
   selectedPatientId = 0;
   length = 0;
@@ -40,17 +42,11 @@ export class PatientTreatmentPlansComponent {
   pageSize = 10;
   pageEvent: PageEvent = new PageEvent();
 
-  readonly statusLabels: Record<TreatmentPlanStatus, string> = {
-    [TreatmentPlanStatus.DRAFT]: 'Borrador',
-    [TreatmentPlanStatus.PROPOSED]: 'Propuesto',
-    [TreatmentPlanStatus.ACCEPTED]: 'Aceptado',
-    [TreatmentPlanStatus.IN_PROGRESS]: 'En progreso',
-    [TreatmentPlanStatus.COMPLETED]: 'Completado',
-    [TreatmentPlanStatus.CANCELLED]: 'Cancelado',
-  };
+  readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
 
   constructor(
     private route: ActivatedRoute,
+    private router: Router,
     private treatmentPlanService: TreatmentPlanService,
     private snackBar: MatSnackBar,
     public dialog: MatDialog,
@@ -130,12 +126,19 @@ export class PatientTreatmentPlansComponent {
     });
   }
 
+  goToTreatmentPlanDetail(treatmentPlanId: number): void {
+    this.router.navigate(['treatment-plan-detail', {
+      id: treatmentPlanId,
+      patientId: this.selectedPatientId
+    }]);
+  }
+
   getStatusLabel(status: TreatmentPlanStatus): string {
     return this.statusLabels[status] ?? status;
   }
 
   getStatusClass(status: TreatmentPlanStatus): string {
-    return `status-${status.toLowerCase().replace('_', '-')}`;
+    return `status-${status.toLowerCase().replace(/_/g, '-')}`;
   }
 
   toCurrencyValue(value: number | string): number {

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
@@ -1,6 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { Component, ElementRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
 import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
 import { MatSnackBar } from '@angular/material/snack-bar';
@@ -8,10 +9,11 @@ import { MatTableModule } from '@angular/material/table';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute } from '@angular/router';
 import { NgxSpinnerModule, NgxSpinnerService } from 'ngx-spinner';
-import { TreatmentPlan, TreatmentPlanStatus } from '../../../core/models/treatment-plan.model';
+import { CreateTreatmentPlanRequest, TreatmentPlan, TreatmentPlanStatus } from '../../../core/models/treatment-plan.model';
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
 import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
 import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
+import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
 
 @Component({
   selector: 'app-patient-treatment-plans',
@@ -19,6 +21,7 @@ import { NoDataFoundComponent } from '../../../shared/components/no-data-found/n
     CommonModule,
     NavBarComponent,
     MatButtonModule,
+    MatDialogModule,
     MatIconModule,
     MatPaginatorModule,
     MatTableModule,
@@ -50,6 +53,7 @@ export class PatientTreatmentPlansComponent {
     private route: ActivatedRoute,
     private treatmentPlanService: TreatmentPlanService,
     private snackBar: MatSnackBar,
+    public dialog: MatDialog,
     private spinner: NgxSpinnerService,
     private elementRef: ElementRef,
     private matIconRegistry: MatIconRegistry,
@@ -95,6 +99,35 @@ export class PatientTreatmentPlansComponent {
     this.pageSize = e.pageSize;
     this.pageIndex = e.pageIndex;
     this.loadTreatmentPlans(this.pageIndex + 1);
+  }
+
+  openTreatmentPlanDialog(): void {
+    const dialogRef = this.dialog.open(TreatmentPlanMgmtDialogComponent, {
+      minWidth: '45vw',
+      maxWidth: '720px',
+      panelClass: 'custom-dialog-container'
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.createTreatmentPlan(result);
+      }
+    });
+  }
+
+  createTreatmentPlan(payload: CreateTreatmentPlanRequest): void {
+    this.spinner.show();
+    this.treatmentPlanService.createTreatmentPlan(this.selectedPatientId, payload).subscribe({
+      next: response => {
+        this.spinner.hide();
+        this.openSnackbar(response.message || 'Plan de tratamiento creado correctamente', 'Ok');
+        this.loadTreatmentPlans(1);
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
   }
 
   getStatusLabel(status: TreatmentPlanStatus): string {

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
@@ -1,0 +1,124 @@
+import { CommonModule } from '@angular/common';
+import { Component, ElementRef } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
+import { MatPaginatorModule, PageEvent } from '@angular/material/paginator';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { DomSanitizer } from '@angular/platform-browser';
+import { ActivatedRoute } from '@angular/router';
+import { NgxSpinnerModule, NgxSpinnerService } from 'ngx-spinner';
+import { TreatmentPlan, TreatmentPlanStatus } from '../../../core/models/treatment-plan.model';
+import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
+import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
+import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
+
+@Component({
+  selector: 'app-patient-treatment-plans',
+  imports: [
+    CommonModule,
+    NavBarComponent,
+    MatButtonModule,
+    MatIconModule,
+    MatPaginatorModule,
+    MatTableModule,
+    NgxSpinnerModule,
+    NoDataFoundComponent
+  ],
+  templateUrl: './patient-treatment-plans.component.html',
+  styleUrl: './patient-treatment-plans.component.scss'
+})
+export class PatientTreatmentPlansComponent {
+  displayedColumns: string[] = ['title', 'status', 'startDate', 'endDate', 'total', 'createdAt'];
+  dataSource: TreatmentPlan[] = [];
+  selectedPatientId = 0;
+  length = 0;
+  pageIndex = 0;
+  pageSize = 10;
+  pageEvent: PageEvent = new PageEvent();
+
+  readonly statusLabels: Record<TreatmentPlanStatus, string> = {
+    [TreatmentPlanStatus.DRAFT]: 'Borrador',
+    [TreatmentPlanStatus.PROPOSED]: 'Propuesto',
+    [TreatmentPlanStatus.ACCEPTED]: 'Aceptado',
+    [TreatmentPlanStatus.IN_PROGRESS]: 'En progreso',
+    [TreatmentPlanStatus.COMPLETED]: 'Completado',
+    [TreatmentPlanStatus.CANCELLED]: 'Cancelado',
+  };
+
+  constructor(
+    private route: ActivatedRoute,
+    private treatmentPlanService: TreatmentPlanService,
+    private snackBar: MatSnackBar,
+    private spinner: NgxSpinnerService,
+    private elementRef: ElementRef,
+    private matIconRegistry: MatIconRegistry,
+    private domSanitizer: DomSanitizer
+  ) {
+    this.matIconRegistry.addSvgIcon(
+      'recetas',
+      this.domSanitizer.bypassSecurityTrustResourceUrl('/icons/dashboard_recetas.svg')
+    );
+  }
+
+  ngOnInit(): void {
+    this.selectedPatientId = Number(this.route.snapshot.paramMap.get('id'));
+    if (this.selectedPatientId) {
+      this.loadTreatmentPlans();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.elementRef.nativeElement.ownerDocument.body.style.backgroundColor = '#ffffff';
+  }
+
+  loadTreatmentPlans(page: number = 1): void {
+    this.spinner.show();
+    this.treatmentPlanService.listTreatmentPlansByPatient(this.selectedPatientId, page, this.pageSize).subscribe({
+      next: response => {
+        this.dataSource = response.data?.results ?? [];
+        this.length = response.data?.total ?? 0;
+        this.pageIndex = (response.data?.page ?? 1) - 1;
+        this.pageSize = response.data?.perPage ?? this.pageSize;
+        this.spinner.hide();
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  handlePageEvent(e: PageEvent): void {
+    this.pageEvent = e;
+    this.length = e.length;
+    this.pageSize = e.pageSize;
+    this.pageIndex = e.pageIndex;
+    this.loadTreatmentPlans(this.pageIndex + 1);
+  }
+
+  getStatusLabel(status: TreatmentPlanStatus): string {
+    return this.statusLabels[status] ?? status;
+  }
+
+  getStatusClass(status: TreatmentPlanStatus): string {
+    return `status-${status.toLowerCase().replace('_', '-')}`;
+  }
+
+  toCurrencyValue(value: number | string): number {
+    return Number(value) || 0;
+  }
+
+  openSnackbar(message: string, action: string): void {
+    this.snackBar.open(message, action, {
+      duration: 3000
+    });
+  }
+
+  private getErrorMessage(error: any): string {
+    return error?.error?.error?.message
+      ?? error?.error?.message
+      ?? error?.message
+      ?? 'Ocurrio un problema al procesar tu solicitud';
+  }
+}

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
@@ -14,6 +14,7 @@ import { CreateTreatmentPlanRequest, TREATMENT_PLAN_STATUS_LABELS, TreatmentPlan
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
 import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
 import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
+import { ConfirmDialogComponent } from '../../../shared/dialogs/confirm-dialog/confirm-dialog.component';
 import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
 
 @Component({
@@ -131,6 +132,40 @@ export class PatientTreatmentPlansComponent {
       id: treatmentPlanId,
       patientId: this.selectedPatientId
     }]);
+  }
+
+  confirmDeleteTreatmentPlan(treatmentPlan: TreatmentPlan): void {
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: 'Eliminar plan de tratamiento',
+        message: `Estas seguro de eliminar "${treatmentPlan.title}"? Tambien se eliminaran sus tratamientos.`,
+        confirmText: 'Eliminar'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.deleteTreatmentPlan(treatmentPlan.id);
+      }
+    });
+  }
+
+  deleteTreatmentPlan(treatmentPlanId: number): void {
+    this.spinner.show();
+    this.treatmentPlanService.cancelTreatmentPlan(treatmentPlanId).subscribe({
+      next: response => {
+        this.spinner.hide();
+        this.openSnackbar(response.message || 'Plan de tratamiento eliminado correctamente', 'Ok');
+        const pageToLoad = this.dataSource.length === 1 && this.pageIndex > 0
+          ? this.pageIndex
+          : this.pageIndex + 1;
+        this.loadTreatmentPlans(pageToLoad);
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
   }
 
   getStatusLabel(status: TreatmentPlanStatus): string {

--- a/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
+++ b/src/app/features/patients/patient-treatment-plans/patient-treatment-plans.component.ts
@@ -121,7 +121,7 @@ export class PatientTreatmentPlansComponent {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        this.createTreatmentPlan(result);
+        this.createTreatmentPlan(result.treatmentPlan);
       }
     });
   }

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
@@ -24,6 +24,19 @@
         </div>
         <div class="col-4">
             <div class="actions_container">
+                @if (treatmentPlan) {
+                <button mat-fab extended class="logout-navbar-button secondary-action" (click)="openEditTreatmentPlanDialog()">Editar plan</button>
+                <mat-form-field class="status-select" appearance="outline">
+                    <mat-label>Estado</mat-label>
+                    <mat-select [value]="selectedStatus" (selectionChange)="selectedStatus = $event.value">
+                        @for (status of statusOptions; track status) {
+                        <mat-option [value]="status">{{getStatusLabel(status)}}</mat-option>
+                        }
+                    </mat-select>
+                </mat-form-field>
+                <button mat-fab extended class="logout-navbar-button secondary-action" [disabled]="!isStatusChanged()"
+                    (click)="confirmStatusUpdate()">Actualizar estado</button>
+                }
                 <button mat-fab extended class="logout-navbar-button" (click)="goBack()">Volver</button>
             </div>
         </div>

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
@@ -144,7 +144,10 @@
     </section>
 
     <section class="detail-section">
-        <p class="section_title">Items del plan</p>
+        <div class="section_header">
+            <p class="section_title">Items del plan</p>
+            <button mat-fab extended class="logout-navbar-button" (click)="openTreatmentPlanItemDialog()">Agregar tratamiento</button>
+        </div>
         @if (treatmentPlanItems.length > 0) {
         <table mat-table [dataSource]="treatmentPlanItems" class="mat-elevation-z0 info-table">
             <ng-container matColumnDef="name">
@@ -212,6 +215,30 @@
                 <th mat-header-cell *matHeaderCellDef class="date-header-column"> Completado </th>
                 <td mat-cell *matCellDef="let element" class="table-content-column">
                     {{element.completed_at ? (element.completed_at | date) : '--'}}
+                </td>
+            </ng-container>
+
+            <ng-container matColumnDef="actions">
+                <th mat-header-cell *matHeaderCellDef class="actions-header-column"> Acciones </th>
+                <td mat-cell *matCellDef="let element" class="actions-content-column">
+                    <div class="item-actions">
+                        <mat-form-field class="item-status-select" appearance="outline">
+                            <mat-label>Estado</mat-label>
+                            <mat-select [value]="getSelectedItemStatus(element)"
+                                [disabled]="isItemProcessing(element.id)"
+                                (selectionChange)="setSelectedItemStatus(element.id, $event.value)">
+                                @for (status of itemStatusOptions; track status) {
+                                <mat-option [value]="status">{{getItemStatusLabel(status)}}</mat-option>
+                                }
+                            </mat-select>
+                        </mat-form-field>
+                        <button mat-button color="primary" [disabled]="!isItemStatusChanged(element) || isItemProcessing(element.id)"
+                            (click)="confirmItemStatusUpdate(element)">Actualizar</button>
+                        <button mat-button color="primary" [disabled]="isItemProcessing(element.id)"
+                            (click)="openEditTreatmentPlanItemDialog(element)">Editar</button>
+                        <button mat-button color="warn" [disabled]="isItemProcessing(element.id)"
+                            (click)="confirmDeleteTreatmentPlanItem(element)">Eliminar</button>
+                    </div>
                 </td>
             </ng-container>
 

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
@@ -1,0 +1,216 @@
+<app-nav-bar></app-nav-bar>
+<ngx-spinner type="ball-newton-cradle"></ngx-spinner>
+
+<div class="container">
+    <div class="row navigation_row">
+        <div class="col-12">
+            <span class="pacientes_navigation">Inicio > Pacientes > Planes de Tratamiento > Detalle</span>
+        </div>
+    </div>
+
+    <div class="row pacientes_header_row">
+        <div class="col-8">
+            <div class="title_container">
+                <mat-icon svgIcon="recetas" class="dashboard_agenda_icon"></mat-icon>
+                <div>
+                    <span class="pacientes_title">{{treatmentPlan?.title || 'Detalle del plan'}}</span>
+                    @if (treatmentPlan?.status) {
+                    <span class="status-badge header-status" [ngClass]="getStatusClass(treatmentPlan!.status)">
+                        {{getStatusLabel(treatmentPlan!.status)}}
+                    </span>
+                    }
+                </div>
+            </div>
+        </div>
+        <div class="col-4">
+            <div class="actions_container">
+                <button mat-fab extended class="logout-navbar-button" (click)="goBack()">Volver</button>
+            </div>
+        </div>
+    </div>
+
+    @if (treatmentPlan) {
+    <section class="detail-section">
+        <p class="section_title">Informacion general</p>
+        <div class="info-grid">
+            <div class="info-item">
+                <span class="info-label">Plan</span>
+                <span class="info-value">{{getDisplayValue(treatmentPlan.title)}}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Estado</span>
+                <span class="info-value">{{getStatusLabel(treatmentPlan.status)}}</span>
+            </div>
+        </div>
+    </section>
+
+    @if (hasClinicalInfo()) {
+    <section class="detail-section">
+        <p class="section_title">Informacion clinica</p>
+        <div class="info-grid">
+            @if (treatmentPlan.description) {
+            <div class="info-item wide">
+                <span class="info-label">Descripcion</span>
+                <span class="info-value">{{treatmentPlan.description}}</span>
+            </div>
+            }
+            @if (treatmentPlan.diagnosis) {
+            <div class="info-item wide">
+                <span class="info-label">Diagnostico</span>
+                <span class="info-value">{{treatmentPlan.diagnosis}}</span>
+            </div>
+            }
+            @if (treatmentPlan.patient_complaint) {
+            <div class="info-item wide">
+                <span class="info-label">Motivo de consulta</span>
+                <span class="info-value">{{treatmentPlan.patient_complaint}}</span>
+            </div>
+            }
+            @if (treatmentPlan.clinical_observations) {
+            <div class="info-item wide">
+                <span class="info-label">Observaciones clinicas</span>
+                <span class="info-value">{{treatmentPlan.clinical_observations}}</span>
+            </div>
+            }
+            @if (treatmentPlan.prognosis) {
+            <div class="info-item wide">
+                <span class="info-label">Pronostico</span>
+                <span class="info-value">{{treatmentPlan.prognosis}}</span>
+            </div>
+            }
+        </div>
+    </section>
+    }
+
+    <section class="detail-section">
+        <p class="section_title">Fechas</p>
+        <div class="info-grid">
+            <div class="info-item">
+                <span class="info-label">Inicio estimado</span>
+                <span class="info-value">{{treatmentPlan.estimated_start_date ? (treatmentPlan.estimated_start_date | date) : '--'}}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Fin estimado</span>
+                <span class="info-value">{{treatmentPlan.estimated_end_date ? (treatmentPlan.estimated_end_date | date) : '--'}}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Aceptado</span>
+                <span class="info-value">{{treatmentPlan.accepted_at ? (treatmentPlan.accepted_at | date) : '--'}}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Rechazado / cancelado</span>
+                <span class="info-value">{{treatmentPlan.rejected_at ? (treatmentPlan.rejected_at | date) : '--'}}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Creacion</span>
+                <span class="info-value">{{treatmentPlan.created_at ? (treatmentPlan.created_at | date) : '--'}}</span>
+            </div>
+            <div class="info-item">
+                <span class="info-label">Ultima actualizacion</span>
+                <span class="info-value">{{treatmentPlan.updated_at ? (treatmentPlan.updated_at | date) : '--'}}</span>
+            </div>
+        </div>
+    </section>
+
+    <section class="detail-section">
+        <p class="section_title">Resumen financiero</p>
+        <div class="financial-grid">
+            <div class="financial-item">
+                <span class="info-label">Subtotal</span>
+                <span class="financial-value">{{toCurrencyValue(treatmentPlan.subtotal) | currency:'MXN':'symbol':'1.2-2'}}</span>
+            </div>
+            <div class="financial-item">
+                <span class="info-label">Descuento</span>
+                <span class="financial-value">{{toCurrencyValue(treatmentPlan.discount) | currency:'MXN':'symbol':'1.2-2'}}</span>
+            </div>
+            <div class="financial-item total">
+                <span class="info-label">Total</span>
+                <span class="financial-value">{{toCurrencyValue(treatmentPlan.total) | currency:'MXN':'symbol':'1.2-2'}}</span>
+            </div>
+        </div>
+    </section>
+
+    <section class="detail-section">
+        <p class="section_title">Items del plan</p>
+        @if (treatmentPlanItems.length > 0) {
+        <table mat-table [dataSource]="treatmentPlanItems" class="mat-elevation-z0 info-table">
+            <ng-container matColumnDef="name">
+                <th mat-header-cell *matHeaderCellDef class="name-header-column"> Item </th>
+                <td mat-cell *matCellDef="let element" class="name-content-column">
+                    <div>{{element.name}}</div>
+                    @if (element.description) {
+                    <span class="item-description">{{element.description}}</span>
+                    }
+                    @if (element.notes) {
+                    <span class="item-description">Notas: {{element.notes}}</span>
+                    }
+                </td>
+            </ng-container>
+
+            <ng-container matColumnDef="tooth">
+                <th mat-header-cell *matHeaderCellDef class="short-header-column"> Diente </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column"> {{getDisplayValue(element.tooth)}} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="area">
+                <th mat-header-cell *matHeaderCellDef class="short-header-column"> Area </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column"> {{getDisplayValue(element.area)}} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="quantity">
+                <th mat-header-cell *matHeaderCellDef class="short-header-column"> Cant. </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column"> {{getDisplayValue(element.quantity)}} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="unitPrice">
+                <th mat-header-cell *matHeaderCellDef class="money-header-column"> Precio </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column">
+                    {{toCurrencyValue(element.unit_price) | currency:'MXN':'symbol':'1.2-2'}}
+                </td>
+            </ng-container>
+
+            <ng-container matColumnDef="subtotal">
+                <th mat-header-cell *matHeaderCellDef class="money-header-column"> Subtotal </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column">
+                    {{toCurrencyValue(element.subtotal) | currency:'MXN':'symbol':'1.2-2'}}
+                </td>
+            </ng-container>
+
+            <ng-container matColumnDef="phase">
+                <th mat-header-cell *matHeaderCellDef class="phase-header-column"> Fase </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column"> {{getDisplayValue(element.phase)}} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="priority">
+                <th mat-header-cell *matHeaderCellDef class="status-header-column"> Prioridad </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column"> {{getPriorityLabel(element.priority)}} </td>
+            </ng-container>
+
+            <ng-container matColumnDef="status">
+                <th mat-header-cell *matHeaderCellDef class="status-header-column"> Estado </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column">
+                    <span class="status-badge" [ngClass]="getStatusClass(element.status)">
+                        {{getItemStatusLabel(element.status)}}
+                    </span>
+                </td>
+            </ng-container>
+
+            <ng-container matColumnDef="completedAt">
+                <th mat-header-cell *matHeaderCellDef class="date-header-column"> Completado </th>
+                <td mat-cell *matCellDef="let element" class="table-content-column">
+                    {{element.completed_at ? (element.completed_at | date) : '--'}}
+                </td>
+            </ng-container>
+
+            <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+            <tr mat-row *matRowDef="let row; columns: displayedColumns;"></tr>
+        </table>
+        }
+        @if (treatmentPlanItems.length === 0) {
+        <app-no-data-found [title]="'Este plan todavia no tiene items'"
+            [message]="'Cuando se agreguen procedimientos, apareceran en esta seccion.'">
+        </app-no-data-found>
+        }
+    </section>
+    }
+</div>

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
@@ -26,16 +26,6 @@
             <div class="actions_container">
                 @if (treatmentPlan) {
                 <button mat-fab extended class="logout-navbar-button secondary-action" (click)="openEditTreatmentPlanDialog()">Editar plan</button>
-                <mat-form-field class="status-select" appearance="outline">
-                    <mat-label>Estado</mat-label>
-                    <mat-select [value]="selectedStatus" (selectionChange)="selectedStatus = $event.value">
-                        @for (status of statusOptions; track status) {
-                        <mat-option [value]="status">{{getStatusLabel(status)}}</mat-option>
-                        }
-                    </mat-select>
-                </mat-form-field>
-                <button mat-fab extended class="logout-navbar-button secondary-action" [disabled]="!isStatusChanged()"
-                    (click)="confirmStatusUpdate()">Actualizar estado</button>
                 }
                 <button mat-fab extended class="logout-navbar-button" (click)="goBack()">Volver</button>
             </div>

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.html
@@ -40,10 +40,6 @@
                 <span class="info-label">Plan</span>
                 <span class="info-value">{{getDisplayValue(treatmentPlan.title)}}</span>
             </div>
-            <div class="info-item">
-                <span class="info-label">Estado</span>
-                <span class="info-value">{{getStatusLabel(treatmentPlan.status)}}</span>
-            </div>
         </div>
     </section>
 
@@ -212,22 +208,12 @@
                 <th mat-header-cell *matHeaderCellDef class="actions-header-column"> Acciones </th>
                 <td mat-cell *matCellDef="let element" class="actions-content-column">
                     <div class="item-actions">
-                        <mat-form-field class="item-status-select" appearance="outline">
-                            <mat-label>Estado</mat-label>
-                            <mat-select [value]="getSelectedItemStatus(element)"
-                                [disabled]="isItemProcessing(element.id)"
-                                (selectionChange)="setSelectedItemStatus(element.id, $event.value)">
-                                @for (status of itemStatusOptions; track status) {
-                                <mat-option [value]="status">{{getItemStatusLabel(status)}}</mat-option>
-                                }
-                            </mat-select>
-                        </mat-form-field>
-                        <button mat-button color="primary" [disabled]="!isItemStatusChanged(element) || isItemProcessing(element.id)"
-                            (click)="confirmItemStatusUpdate(element)">Actualizar</button>
-                        <button mat-button color="primary" [disabled]="isItemProcessing(element.id)"
-                            (click)="openEditTreatmentPlanItemDialog(element)">Editar</button>
-                        <button mat-button color="warn" [disabled]="isItemProcessing(element.id)"
-                            (click)="confirmDeleteTreatmentPlanItem(element)">Eliminar</button>
+                        <mat-icon class="item-action-icon" fontIcon="edit" matTooltip="Editar estado"
+                            [class.disabled-action]="isItemProcessing(element.id)"
+                            (click)="openEditTreatmentPlanItemStatusDialog(element)"></mat-icon>
+                        <mat-icon class="item-action-icon delete-action-icon" fontIcon="delete" matTooltip="Eliminar"
+                            [class.disabled-action]="isItemProcessing(element.id)"
+                            (click)="confirmDeleteTreatmentPlanItem(element)"></mat-icon>
                     </div>
                 </td>
             </ng-container>

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
@@ -232,7 +232,7 @@
 }
 
 .actions-header-column {
-  width: 18%;
+  width: 8%;
 }
 
 .name-content-column,
@@ -256,14 +256,26 @@
 .item-actions {
   display: flex;
   align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
+  justify-content: center;
+  gap: 10px;
   padding: 6px 0;
 }
 
-.item-status-select {
-  width: 150px;
-  margin-bottom: -20px;
+.item-action-icon {
+  width: 20px;
+  height: auto;
+  cursor: pointer;
+  color: $main--blue;
+}
+
+.delete-action-icon {
+  color: #EB5757;
+}
+
+.disabled-action {
+  color: #C0D9FF;
+  cursor: not-allowed;
+  pointer-events: none;
 }
 
 @media (max-width: 768px) {

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
@@ -1,0 +1,238 @@
+@use "../../../../vars.scss" as *;
+
+.navigation_row {
+  margin-top: 15px;
+  margin-bottom: 30px;
+}
+
+.pacientes_header_row {
+  margin-top: 15px;
+  margin-bottom: 20px;
+}
+
+.pacientes_navigation {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 18px;
+  line-height: 21px;
+  display: flex;
+  align-items: center;
+  letter-spacing: 0.02em;
+  color: $primary--blue;
+}
+
+.title_container {
+  display: flex;
+  align-items: center;
+}
+
+.dashboard_agenda_icon {
+  width: 50px;
+  height: auto;
+  margin-right: 20px;
+}
+
+.pacientes_title {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 26px;
+  line-height: 30px;
+  letter-spacing: 0.01em;
+  color: $primary--blue;
+  display: block;
+}
+
+.actions_container {
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+}
+
+.logout-navbar-button {
+  height: 30px;
+  color: #fff;
+  background-color: $second--blue;
+  letter-spacing: 0.02em;
+  box-shadow: none !important;
+}
+
+.detail-section {
+  margin: 25px 0;
+}
+
+.section_title {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 22px;
+  line-height: 26px;
+  letter-spacing: 0.01em;
+  color: $primary--blue;
+  margin-bottom: 15px;
+}
+
+.info-grid,
+.financial-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 24px;
+}
+
+.financial-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.info-item,
+.financial-item {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid #C0D9FF;
+  padding: 12px;
+  background-color: #fff;
+}
+
+.info-item.wide {
+  grid-column: 1 / -1;
+}
+
+.info-label {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16px;
+  color: $main--blue;
+  margin-bottom: 6px;
+}
+
+.info-value,
+.financial-value {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: #7A7A7A;
+}
+
+.financial-item.total .financial-value {
+  color: $main--blue;
+  font-weight: 500;
+}
+
+.status-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 92px;
+  padding: 4px 10px;
+  border-radius: 4px;
+  font-size: 12px;
+  line-height: 16px;
+  color: $main--blue;
+  background-color: #EAF2FF;
+}
+
+.header-status {
+  margin-top: 8px;
+}
+
+.status-accepted,
+.status-completed {
+  color: #219653;
+  background-color: #E9F8EF;
+}
+
+.status-in-progress,
+.status-proposed,
+.status-approved,
+.status-pending {
+  color: #407DDA;
+  background-color: #EAF2FF;
+}
+
+.status-cancelled {
+  color: #EB5757;
+  background-color: #FDECEC;
+}
+
+.status-draft {
+  color: #7A7A7A;
+  background-color: #F2F2F2;
+}
+
+.info-table {
+  background-color: #fff;
+  width: 100%;
+}
+
+.mat-mdc-row .mat-mdc-cell {
+  border: 1px solid #C0D9FF;
+}
+
+.mat-mdc-header-row .mat-mdc-header-cell {
+  font-family: 'Roboto Condensed';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 16px;
+  letter-spacing: 0.01em;
+  color: $main--blue;
+  border: 2px solid #C0D9FF;
+}
+
+.name-header-column {
+  width: 24%;
+}
+
+.short-header-column {
+  width: 7%;
+}
+
+.money-header-column {
+  width: 9%;
+}
+
+.phase-header-column {
+  width: 10%;
+}
+
+.status-header-column {
+  width: 10%;
+}
+
+.date-header-column {
+  width: 10%;
+}
+
+.name-content-column,
+.table-content-column {
+  font-family: 'Roboto';
+  font-style: normal;
+  font-weight: 400;
+  font-size: 14px;
+  line-height: 20px;
+  color: #7A7A7A;
+}
+
+.item-description {
+  display: block;
+  color: #7A7A7A;
+  font-size: 12px;
+  line-height: 18px;
+}
+
+@media (max-width: 768px) {
+  .info-grid,
+  .financial-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .actions_container {
+    justify-content: flex-start;
+    margin-top: 16px;
+  }
+}

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
@@ -70,11 +70,6 @@
   min-width: 116px;
 }
 
-.status-select {
-  width: 170px;
-  margin-bottom: -20px;
-}
-
 .detail-section {
   margin: 25px 0;
 }

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
@@ -90,6 +90,18 @@
   margin-bottom: 15px;
 }
 
+.section_header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 15px;
+}
+
+.section_header .section_title {
+  margin-bottom: 0;
+}
+
 .info-grid,
 .financial-grid {
   display: grid;
@@ -224,8 +236,13 @@
   width: 10%;
 }
 
+.actions-header-column {
+  width: 18%;
+}
+
 .name-content-column,
-.table-content-column {
+.table-content-column,
+.actions-content-column {
   font-family: 'Roboto';
   font-style: normal;
   font-weight: 400;
@@ -239,6 +256,19 @@
   color: #7A7A7A;
   font-size: 12px;
   line-height: 18px;
+}
+
+.item-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 6px 0;
+}
+
+.item-status-select {
+  width: 150px;
+  margin-bottom: -20px;
 }
 
 @media (max-width: 768px) {

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.scss
@@ -49,6 +49,8 @@
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 10px;
+  flex-wrap: wrap;
 }
 
 .logout-navbar-button {
@@ -57,6 +59,20 @@
   background-color: $second--blue;
   letter-spacing: 0.02em;
   box-shadow: none !important;
+}
+
+.logout-navbar-button:disabled {
+  background-color: #C0D9FF;
+  color: #fff;
+}
+
+.secondary-action {
+  min-width: 116px;
+}
+
+.status-select {
+  width: 170px;
+  margin-bottom: -20px;
 }
 
 .detail-section {

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.spec.ts
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreatmentPlanDetailComponent } from './treatment-plan-detail.component';
+
+describe('TreatmentPlanDetailComponent', () => {
+  let component: TreatmentPlanDetailComponent;
+  let fixture: ComponentFixture<TreatmentPlanDetailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TreatmentPlanDetailComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TreatmentPlanDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
@@ -14,18 +14,24 @@ import {
   TREATMENT_PLAN_ITEM_PRIORITY_LABELS,
   TREATMENT_PLAN_ITEM_STATUS_LABELS,
   TREATMENT_PLAN_STATUS_LABELS,
+  CreateTreatmentPlanItemRequest,
   TreatmentPlan,
   TreatmentPlanItem,
   TreatmentPlanItemPriority,
   TreatmentPlanItemStatus,
   TreatmentPlanStatus,
+  UpdateTreatmentPlanItemRequest,
+  UpdateTreatmentPlanItemStatusRequest,
   UpdateTreatmentPlanRequest,
   UpdateTreatmentPlanStatusRequest
 } from '../../../core/models/treatment-plan.model';
+import { UserConcept } from '../../../core/models/user-concept.model';
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
+import { UserConceptsService } from '../../../core/services/user-concepts.service';
 import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
 import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
 import { ConfirmDialogComponent } from '../../../shared/dialogs/confirm-dialog/confirm-dialog.component';
+import { TreatmentPlanItemMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component';
 import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
 
 @Component({
@@ -50,18 +56,23 @@ export class TreatmentPlanDetailComponent {
   patientId = 0;
   treatmentPlan: TreatmentPlan | null = null;
   selectedStatus: TreatmentPlanStatus | null = null;
-  displayedColumns: string[] = ['name', 'tooth', 'area', 'quantity', 'unitPrice', 'subtotal', 'phase', 'priority', 'status', 'completedAt'];
+  conceptList: UserConcept[] = [];
+  selectedItemStatuses: Record<number, TreatmentPlanItemStatus> = {};
+  processingItemIds = new Set<number>();
+  displayedColumns: string[] = ['name', 'tooth', 'area', 'quantity', 'unitPrice', 'subtotal', 'phase', 'priority', 'status', 'completedAt', 'actions'];
 
   readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
   readonly itemStatusLabels = TREATMENT_PLAN_ITEM_STATUS_LABELS;
   readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
   readonly statusOptions = Object.values(TreatmentPlanStatus);
+  readonly itemStatusOptions = Object.values(TreatmentPlanItemStatus);
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private location: Location,
     private treatmentPlanService: TreatmentPlanService,
+    private userConceptsService: UserConceptsService,
     public dialog: MatDialog,
     private snackBar: MatSnackBar,
     private spinner: NgxSpinnerService,
@@ -81,6 +92,7 @@ export class TreatmentPlanDetailComponent {
 
     if (this.treatmentPlanId) {
       this.loadTreatmentPlanDetail();
+      this.loadUserConcepts();
     }
   }
 
@@ -94,11 +106,23 @@ export class TreatmentPlanDetailComponent {
       next: response => {
         this.treatmentPlan = response.data;
         this.selectedStatus = response.data?.status ?? null;
+        this.syncSelectedItemStatuses();
         this.spinner.hide();
       },
       error: error => {
         this.spinner.hide();
         this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  loadUserConcepts(): void {
+    this.userConceptsService.listUserConcepts(1, 100).subscribe({
+      next: response => {
+        this.conceptList = response.data?.results ?? [];
+      },
+      error: error => {
+        this.openSnackbar(`Ocurrio un error al cargar conceptos: ${this.getErrorMessage(error)}`, 'Ok');
       }
     });
   }
@@ -201,6 +225,162 @@ export class TreatmentPlanDetailComponent {
     });
   }
 
+  openTreatmentPlanItemDialog(): void {
+    const dialogRef = this.dialog.open(TreatmentPlanItemMgmtDialogComponent, {
+      minWidth: '45vw',
+      maxWidth: '760px',
+      panelClass: 'custom-dialog-container',
+      data: {
+        conceptList: this.conceptList
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.createTreatmentPlanItem(result);
+      }
+    });
+  }
+
+  createTreatmentPlanItem(payload: CreateTreatmentPlanItemRequest): void {
+    this.spinner.show();
+    this.treatmentPlanService.createTreatmentPlanItem(this.treatmentPlanId, payload).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Tratamiento agregado correctamente', 'Ok');
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  openEditTreatmentPlanItemDialog(item: TreatmentPlanItem): void {
+    const dialogRef = this.dialog.open(TreatmentPlanItemMgmtDialogComponent, {
+      minWidth: '45vw',
+      maxWidth: '760px',
+      panelClass: 'custom-dialog-container',
+      data: {
+        conceptList: this.conceptList,
+        mode: 'edit',
+        treatmentPlanItem: item
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.updateTreatmentPlanItem(item.id, result);
+      }
+    });
+  }
+
+  updateTreatmentPlanItem(itemId: number, payload: UpdateTreatmentPlanItemRequest): void {
+    this.setItemProcessing(itemId, true);
+    this.treatmentPlanService.updateTreatmentPlanItem(this.treatmentPlanId, itemId, payload).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Tratamiento actualizado correctamente', 'Ok');
+        this.setItemProcessing(itemId, false);
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.setItemProcessing(itemId, false);
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  setSelectedItemStatus(itemId: number, status: TreatmentPlanItemStatus): void {
+    this.selectedItemStatuses[itemId] = status;
+  }
+
+  getSelectedItemStatus(item: TreatmentPlanItem): TreatmentPlanItemStatus {
+    return this.selectedItemStatuses[item.id] ?? item.status;
+  }
+
+  isItemStatusChanged(item: TreatmentPlanItem): boolean {
+    return this.getSelectedItemStatus(item) !== item.status;
+  }
+
+  confirmItemStatusUpdate(item: TreatmentPlanItem): void {
+    const selectedStatus = this.getSelectedItemStatus(item);
+    if (selectedStatus === item.status || this.isItemProcessing(item.id)) {
+      return;
+    }
+
+    if (selectedStatus === TreatmentPlanItemStatus.COMPLETED || selectedStatus === TreatmentPlanItemStatus.CANCELLED) {
+      const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+        data: {
+          title: 'Actualizar estado',
+          message: `¿Seguro que quieres cambiar el estado de "${item.name}" a ${this.getItemStatusLabel(selectedStatus)}?`,
+          confirmText: 'Actualizar'
+        }
+      });
+
+      dialogRef.afterClosed().subscribe(result => {
+        if (result) {
+          this.updateTreatmentPlanItemStatus(item.id, { status: selectedStatus });
+        } else {
+          this.selectedItemStatuses[item.id] = item.status;
+        }
+      });
+      return;
+    }
+
+    this.updateTreatmentPlanItemStatus(item.id, { status: selectedStatus });
+  }
+
+  updateTreatmentPlanItemStatus(itemId: number, payload: UpdateTreatmentPlanItemStatusRequest): void {
+    this.setItemProcessing(itemId, true);
+    this.treatmentPlanService.updateTreatmentPlanItemStatus(this.treatmentPlanId, itemId, payload).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Estado del tratamiento actualizado correctamente', 'Ok');
+        this.setItemProcessing(itemId, false);
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.setItemProcessing(itemId, false);
+        this.syncSelectedItemStatuses();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  confirmDeleteTreatmentPlanItem(item: TreatmentPlanItem): void {
+    if (this.isItemProcessing(item.id)) {
+      return;
+    }
+
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: 'Eliminar tratamiento',
+        message: `¿Seguro que quieres eliminar "${item.name}" del plan?`,
+        confirmText: 'Eliminar'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.deleteTreatmentPlanItem(item.id);
+      }
+    });
+  }
+
+  deleteTreatmentPlanItem(itemId: number): void {
+    this.setItemProcessing(itemId, true);
+    this.treatmentPlanService.deleteTreatmentPlanItem(this.treatmentPlanId, itemId).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Tratamiento eliminado correctamente', 'Ok');
+        this.setItemProcessing(itemId, false);
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.setItemProcessing(itemId, false);
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
   isStatusChanged(): boolean {
     return !!this.selectedStatus && !!this.treatmentPlan && this.selectedStatus !== this.treatmentPlan.status;
   }
@@ -240,5 +420,25 @@ export class TreatmentPlanDetailComponent {
       ?? error?.error?.message
       ?? error?.message
       ?? 'Ocurrio un problema al procesar tu solicitud';
+  }
+
+  private syncSelectedItemStatuses(): void {
+    this.selectedItemStatuses = {};
+    this.treatmentPlanItems.forEach(item => {
+      this.selectedItemStatuses[item.id] = item.status;
+    });
+  }
+
+  isItemProcessing(itemId: number): boolean {
+    return this.processingItemIds.has(itemId);
+  }
+
+  private setItemProcessing(itemId: number, isProcessing: boolean): void {
+    if (isProcessing) {
+      this.processingItemIds.add(itemId);
+      return;
+    }
+
+    this.processingItemIds.delete(itemId);
   }
 }

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
@@ -2,11 +2,10 @@ import { CommonModule, Location } from '@angular/common';
 import { Component, ElementRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDialog, MatDialogModule } from '@angular/material/dialog';
-import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
-import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
+import { MatTooltipModule } from '@angular/material/tooltip';
 import { DomSanitizer } from '@angular/platform-browser';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NgxSpinnerModule, NgxSpinnerService } from 'ngx-spinner';
@@ -20,9 +19,9 @@ import {
   TreatmentPlanItemPriority,
   TreatmentPlanItemStatus,
   TreatmentPlanStatus,
-  UpdateTreatmentPlanItemRequest,
   UpdateTreatmentPlanItemStatusRequest,
-  UpdateTreatmentPlanRequest
+  UpdateTreatmentPlanRequest,
+  UpdateTreatmentPlanStatusRequest
 } from '../../../core/models/treatment-plan.model';
 import { UserConcept } from '../../../core/models/user-concept.model';
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
@@ -31,7 +30,10 @@ import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.comp
 import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
 import { ConfirmDialogComponent } from '../../../shared/dialogs/confirm-dialog/confirm-dialog.component';
 import { TreatmentPlanItemMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component';
-import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
+import {
+  TreatmentPlanMgmtDialogComponent,
+  TreatmentPlanMgmtDialogResult
+} from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
 
 @Component({
   selector: 'app-treatment-plan-detail',
@@ -39,10 +41,9 @@ import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatm
     CommonModule,
     MatButtonModule,
     MatDialogModule,
-    MatFormFieldModule,
     MatIconModule,
-    MatSelectModule,
     MatTableModule,
+    MatTooltipModule,
     NavBarComponent,
     NgxSpinnerModule,
     NoDataFoundComponent
@@ -55,14 +56,12 @@ export class TreatmentPlanDetailComponent {
   patientId = 0;
   treatmentPlan: TreatmentPlan | null = null;
   conceptList: UserConcept[] = [];
-  selectedItemStatuses: Record<number, TreatmentPlanItemStatus> = {};
   processingItemIds = new Set<number>();
   displayedColumns: string[] = ['name', 'tooth', 'area', 'quantity', 'unitPrice', 'subtotal', 'phase', 'priority', 'status', 'completedAt', 'actions'];
 
   readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
   readonly itemStatusLabels = TREATMENT_PLAN_ITEM_STATUS_LABELS;
   readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
-  readonly itemStatusOptions = Object.values(TreatmentPlanItemStatus);
 
   constructor(
     private route: ActivatedRoute,
@@ -102,7 +101,6 @@ export class TreatmentPlanDetailComponent {
     this.treatmentPlanService.getTreatmentPlanDetail(this.treatmentPlanId).subscribe({
       next: response => {
         this.treatmentPlan = response.data;
-        this.syncSelectedItemStatuses();
         this.spinner.hide();
       },
       error: error => {
@@ -163,21 +161,46 @@ export class TreatmentPlanDetailComponent {
 
     dialogRef.afterClosed().subscribe(result => {
       if (result) {
-        this.updateTreatmentPlan(result);
+        this.updateTreatmentPlanFromDialog(result);
       }
     });
   }
 
-  updateTreatmentPlan(payload: UpdateTreatmentPlanRequest): void {
+  updateTreatmentPlanFromDialog(result: TreatmentPlanMgmtDialogResult): void {
+    const selectedStatus = result.status;
+    const shouldUpdateStatus = !!selectedStatus && !!this.treatmentPlan && selectedStatus !== this.treatmentPlan.status;
+
+    this.updateTreatmentPlan(result.treatmentPlan as UpdateTreatmentPlanRequest, shouldUpdateStatus ? selectedStatus : undefined);
+  }
+
+  updateTreatmentPlan(payload: UpdateTreatmentPlanRequest, nextStatus?: TreatmentPlanStatus): void {
     this.spinner.show();
     this.treatmentPlanService.updateTreatmentPlan(this.treatmentPlanId, payload).subscribe({
       next: response => {
+        if (nextStatus) {
+          this.updateTreatmentPlanStatus({ status: nextStatus });
+          return;
+        }
+
         this.openSnackbar(response.message || 'Plan de tratamiento actualizado correctamente', 'Ok');
         this.loadTreatmentPlanDetail();
       },
       error: error => {
         this.spinner.hide();
         this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  updateTreatmentPlanStatus(payload: UpdateTreatmentPlanStatusRequest): void {
+    this.treatmentPlanService.updateTreatmentPlanStatus(this.treatmentPlanId, payload).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Plan de tratamiento actualizado correctamente', 'Ok');
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error al actualizar el estado: ${this.getErrorMessage(error)}`, 'Ok');
       }
     });
   }
@@ -213,78 +236,26 @@ export class TreatmentPlanDetailComponent {
     });
   }
 
-  openEditTreatmentPlanItemDialog(item: TreatmentPlanItem): void {
+  openEditTreatmentPlanItemStatusDialog(item: TreatmentPlanItem): void {
+    if (this.isItemProcessing(item.id)) {
+      return;
+    }
+
     const dialogRef = this.dialog.open(TreatmentPlanItemMgmtDialogComponent, {
-      minWidth: '45vw',
-      maxWidth: '760px',
+      minWidth: '36vw',
+      maxWidth: '560px',
       panelClass: 'custom-dialog-container',
       data: {
-        conceptList: this.conceptList,
-        mode: 'edit',
+        mode: 'status',
         treatmentPlanItem: item
       }
     });
 
     dialogRef.afterClosed().subscribe(result => {
-      if (result) {
-        this.updateTreatmentPlanItem(item.id, result);
+      if (result?.status && result.status !== item.status) {
+        this.updateTreatmentPlanItemStatus(item.id, result);
       }
     });
-  }
-
-  updateTreatmentPlanItem(itemId: number, payload: UpdateTreatmentPlanItemRequest): void {
-    this.setItemProcessing(itemId, true);
-    this.treatmentPlanService.updateTreatmentPlanItem(this.treatmentPlanId, itemId, payload).subscribe({
-      next: response => {
-        this.openSnackbar(response.message || 'Tratamiento actualizado correctamente', 'Ok');
-        this.setItemProcessing(itemId, false);
-        this.loadTreatmentPlanDetail();
-      },
-      error: error => {
-        this.setItemProcessing(itemId, false);
-        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
-      }
-    });
-  }
-
-  setSelectedItemStatus(itemId: number, status: TreatmentPlanItemStatus): void {
-    this.selectedItemStatuses[itemId] = status;
-  }
-
-  getSelectedItemStatus(item: TreatmentPlanItem): TreatmentPlanItemStatus {
-    return this.selectedItemStatuses[item.id] ?? item.status;
-  }
-
-  isItemStatusChanged(item: TreatmentPlanItem): boolean {
-    return this.getSelectedItemStatus(item) !== item.status;
-  }
-
-  confirmItemStatusUpdate(item: TreatmentPlanItem): void {
-    const selectedStatus = this.getSelectedItemStatus(item);
-    if (selectedStatus === item.status || this.isItemProcessing(item.id)) {
-      return;
-    }
-
-    if (selectedStatus === TreatmentPlanItemStatus.COMPLETED || selectedStatus === TreatmentPlanItemStatus.CANCELLED) {
-      const dialogRef = this.dialog.open(ConfirmDialogComponent, {
-        data: {
-          title: 'Actualizar estado',
-          message: `¿Seguro que quieres cambiar el estado de "${item.name}" a ${this.getItemStatusLabel(selectedStatus)}?`,
-          confirmText: 'Actualizar'
-        }
-      });
-
-      dialogRef.afterClosed().subscribe(result => {
-        if (result) {
-          this.updateTreatmentPlanItemStatus(item.id, { status: selectedStatus });
-        } else {
-          this.selectedItemStatuses[item.id] = item.status;
-        }
-      });
-      return;
-    }
-
-    this.updateTreatmentPlanItemStatus(item.id, { status: selectedStatus });
   }
 
   updateTreatmentPlanItemStatus(itemId: number, payload: UpdateTreatmentPlanItemStatusRequest): void {
@@ -297,7 +268,6 @@ export class TreatmentPlanDetailComponent {
       },
       error: error => {
         this.setItemProcessing(itemId, false);
-        this.syncSelectedItemStatuses();
         this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
       }
     });
@@ -373,13 +343,6 @@ export class TreatmentPlanDetailComponent {
       ?? error?.error?.message
       ?? error?.message
       ?? 'Ocurrio un problema al procesar tu solicitud';
-  }
-
-  private syncSelectedItemStatuses(): void {
-    this.selectedItemStatuses = {};
-    this.treatmentPlanItems.forEach(item => {
-      this.selectedItemStatuses[item.id] = item.status;
-    });
   }
 
   isItemProcessing(itemId: number): boolean {

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
@@ -1,7 +1,10 @@
 import { CommonModule, Location } from '@angular/common';
 import { Component, ElementRef } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDialog, MatDialogModule } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
+import { MatSelectModule } from '@angular/material/select';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { MatTableModule } from '@angular/material/table';
 import { DomSanitizer } from '@angular/platform-browser';
@@ -15,18 +18,25 @@ import {
   TreatmentPlanItem,
   TreatmentPlanItemPriority,
   TreatmentPlanItemStatus,
-  TreatmentPlanStatus
+  TreatmentPlanStatus,
+  UpdateTreatmentPlanRequest,
+  UpdateTreatmentPlanStatusRequest
 } from '../../../core/models/treatment-plan.model';
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
 import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
 import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
+import { ConfirmDialogComponent } from '../../../shared/dialogs/confirm-dialog/confirm-dialog.component';
+import { TreatmentPlanMgmtDialogComponent } from '../../../shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component';
 
 @Component({
   selector: 'app-treatment-plan-detail',
   imports: [
     CommonModule,
     MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
     MatIconModule,
+    MatSelectModule,
     MatTableModule,
     NavBarComponent,
     NgxSpinnerModule,
@@ -39,17 +49,20 @@ export class TreatmentPlanDetailComponent {
   treatmentPlanId = 0;
   patientId = 0;
   treatmentPlan: TreatmentPlan | null = null;
+  selectedStatus: TreatmentPlanStatus | null = null;
   displayedColumns: string[] = ['name', 'tooth', 'area', 'quantity', 'unitPrice', 'subtotal', 'phase', 'priority', 'status', 'completedAt'];
 
   readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
   readonly itemStatusLabels = TREATMENT_PLAN_ITEM_STATUS_LABELS;
   readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
+  readonly statusOptions = Object.values(TreatmentPlanStatus);
 
   constructor(
     private route: ActivatedRoute,
     private router: Router,
     private location: Location,
     private treatmentPlanService: TreatmentPlanService,
+    public dialog: MatDialog,
     private snackBar: MatSnackBar,
     private spinner: NgxSpinnerService,
     private elementRef: ElementRef,
@@ -80,6 +93,7 @@ export class TreatmentPlanDetailComponent {
     this.treatmentPlanService.getTreatmentPlanDetail(this.treatmentPlanId).subscribe({
       next: response => {
         this.treatmentPlan = response.data;
+        this.selectedStatus = response.data?.status ?? null;
         this.spinner.hide();
       },
       error: error => {
@@ -110,6 +124,85 @@ export class TreatmentPlanDetailComponent {
       this.treatmentPlan?.clinical_observations ||
       this.treatmentPlan?.prognosis
     );
+  }
+
+  openEditTreatmentPlanDialog(): void {
+    if (!this.treatmentPlan) {
+      return;
+    }
+
+    const dialogRef = this.dialog.open(TreatmentPlanMgmtDialogComponent, {
+      minWidth: '45vw',
+      maxWidth: '720px',
+      panelClass: 'custom-dialog-container',
+      data: {
+        mode: 'edit',
+        treatmentPlan: this.treatmentPlan
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.updateTreatmentPlan(result);
+      }
+    });
+  }
+
+  updateTreatmentPlan(payload: UpdateTreatmentPlanRequest): void {
+    this.spinner.show();
+    this.treatmentPlanService.updateTreatmentPlan(this.treatmentPlanId, payload).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Plan de tratamiento actualizado correctamente', 'Ok');
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  confirmStatusUpdate(): void {
+    if (!this.selectedStatus || !this.treatmentPlan || this.selectedStatus === this.treatmentPlan.status) {
+      return;
+    }
+
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: {
+        title: 'Actualizar estado',
+        message: `¿Seguro que quieres cambiar el estado del plan a ${this.getStatusLabel(this.selectedStatus)}?`,
+        confirmText: 'Actualizar'
+      }
+    });
+
+    dialogRef.afterClosed().subscribe(result => {
+      if (result) {
+        this.updateTreatmentPlanStatus({
+          status: this.selectedStatus as TreatmentPlanStatus
+        });
+      } else {
+        this.selectedStatus = this.treatmentPlan?.status ?? null;
+      }
+    });
+  }
+
+  updateTreatmentPlanStatus(payload: UpdateTreatmentPlanStatusRequest): void {
+    this.spinner.show();
+    this.treatmentPlanService.updateTreatmentPlanStatus(this.treatmentPlanId, payload).subscribe({
+      next: response => {
+        this.openSnackbar(response.message || 'Estado del plan actualizado correctamente', 'Ok');
+        this.loadTreatmentPlanDetail();
+      },
+      error: error => {
+        this.spinner.hide();
+        this.selectedStatus = this.treatmentPlan?.status ?? null;
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  isStatusChanged(): boolean {
+    return !!this.selectedStatus && !!this.treatmentPlan && this.selectedStatus !== this.treatmentPlan.status;
   }
 
   getStatusLabel(status: TreatmentPlanStatus): string {

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
@@ -1,0 +1,151 @@
+import { CommonModule, Location } from '@angular/common';
+import { Component, ElementRef } from '@angular/core';
+import { MatButtonModule } from '@angular/material/button';
+import { MatIconModule, MatIconRegistry } from '@angular/material/icon';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatTableModule } from '@angular/material/table';
+import { DomSanitizer } from '@angular/platform-browser';
+import { ActivatedRoute, Router } from '@angular/router';
+import { NgxSpinnerModule, NgxSpinnerService } from 'ngx-spinner';
+import {
+  TREATMENT_PLAN_ITEM_PRIORITY_LABELS,
+  TREATMENT_PLAN_ITEM_STATUS_LABELS,
+  TREATMENT_PLAN_STATUS_LABELS,
+  TreatmentPlan,
+  TreatmentPlanItem,
+  TreatmentPlanItemPriority,
+  TreatmentPlanItemStatus,
+  TreatmentPlanStatus
+} from '../../../core/models/treatment-plan.model';
+import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
+import { NavBarComponent } from '../../../shared/components/nav-bar/nav-bar.component';
+import { NoDataFoundComponent } from '../../../shared/components/no-data-found/no-data-found.component';
+
+@Component({
+  selector: 'app-treatment-plan-detail',
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatIconModule,
+    MatTableModule,
+    NavBarComponent,
+    NgxSpinnerModule,
+    NoDataFoundComponent
+  ],
+  templateUrl: './treatment-plan-detail.component.html',
+  styleUrl: './treatment-plan-detail.component.scss'
+})
+export class TreatmentPlanDetailComponent {
+  treatmentPlanId = 0;
+  patientId = 0;
+  treatmentPlan: TreatmentPlan | null = null;
+  displayedColumns: string[] = ['name', 'tooth', 'area', 'quantity', 'unitPrice', 'subtotal', 'phase', 'priority', 'status', 'completedAt'];
+
+  readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
+  readonly itemStatusLabels = TREATMENT_PLAN_ITEM_STATUS_LABELS;
+  readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
+
+  constructor(
+    private route: ActivatedRoute,
+    private router: Router,
+    private location: Location,
+    private treatmentPlanService: TreatmentPlanService,
+    private snackBar: MatSnackBar,
+    private spinner: NgxSpinnerService,
+    private elementRef: ElementRef,
+    private matIconRegistry: MatIconRegistry,
+    private domSanitizer: DomSanitizer
+  ) {
+    this.matIconRegistry.addSvgIcon(
+      'recetas',
+      this.domSanitizer.bypassSecurityTrustResourceUrl('/icons/dashboard_recetas.svg')
+    );
+  }
+
+  ngOnInit(): void {
+    this.treatmentPlanId = Number(this.route.snapshot.paramMap.get('id'));
+    this.patientId = Number(this.route.snapshot.paramMap.get('patientId'));
+
+    if (this.treatmentPlanId) {
+      this.loadTreatmentPlanDetail();
+    }
+  }
+
+  ngAfterViewInit(): void {
+    this.elementRef.nativeElement.ownerDocument.body.style.backgroundColor = '#ffffff';
+  }
+
+  loadTreatmentPlanDetail(): void {
+    this.spinner.show();
+    this.treatmentPlanService.getTreatmentPlanDetail(this.treatmentPlanId).subscribe({
+      next: response => {
+        this.treatmentPlan = response.data;
+        this.spinner.hide();
+      },
+      error: error => {
+        this.spinner.hide();
+        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
+      }
+    });
+  }
+
+  goBack(): void {
+    if (this.patientId) {
+      this.router.navigate(['patient-treatment-plans', { id: this.patientId }]);
+      return;
+    }
+
+    this.location.back();
+  }
+
+  get treatmentPlanItems(): TreatmentPlanItem[] {
+    return this.treatmentPlan?.TreatmentPlanItems ?? [];
+  }
+
+  hasClinicalInfo(): boolean {
+    return !!(
+      this.treatmentPlan?.description ||
+      this.treatmentPlan?.diagnosis ||
+      this.treatmentPlan?.patient_complaint ||
+      this.treatmentPlan?.clinical_observations ||
+      this.treatmentPlan?.prognosis
+    );
+  }
+
+  getStatusLabel(status: TreatmentPlanStatus): string {
+    return this.statusLabels[status] ?? status;
+  }
+
+  getItemStatusLabel(status: TreatmentPlanItemStatus): string {
+    return this.itemStatusLabels[status] ?? status;
+  }
+
+  getPriorityLabel(priority: TreatmentPlanItemPriority | null): string {
+    return priority ? this.priorityLabels[priority] ?? priority : '--';
+  }
+
+  getStatusClass(status: TreatmentPlanStatus | TreatmentPlanItemStatus): string {
+    return `status-${status.toLowerCase().replace(/_/g, '-')}`;
+  }
+
+  toCurrencyValue(value: number | string | null | undefined): number {
+    return Number(value) || 0;
+  }
+
+  getDisplayValue(value: string | number | null | undefined): string | number {
+    return value !== null && value !== undefined && value !== '' ? value : '--';
+  }
+
+  openSnackbar(message: string, action: string): void {
+    this.snackBar.open(message, action, {
+      duration: 3000
+    });
+  }
+
+  private getErrorMessage(error: any): string {
+    return error?.error?.error?.message
+      ?? error?.error?.message
+      ?? error?.message
+      ?? 'Ocurrio un problema al procesar tu solicitud';
+  }
+}

--- a/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
+++ b/src/app/features/patients/treatment-plan-detail/treatment-plan-detail.component.ts
@@ -22,8 +22,7 @@ import {
   TreatmentPlanStatus,
   UpdateTreatmentPlanItemRequest,
   UpdateTreatmentPlanItemStatusRequest,
-  UpdateTreatmentPlanRequest,
-  UpdateTreatmentPlanStatusRequest
+  UpdateTreatmentPlanRequest
 } from '../../../core/models/treatment-plan.model';
 import { UserConcept } from '../../../core/models/user-concept.model';
 import { TreatmentPlanService } from '../../../core/services/treatment-plan.service';
@@ -55,7 +54,6 @@ export class TreatmentPlanDetailComponent {
   treatmentPlanId = 0;
   patientId = 0;
   treatmentPlan: TreatmentPlan | null = null;
-  selectedStatus: TreatmentPlanStatus | null = null;
   conceptList: UserConcept[] = [];
   selectedItemStatuses: Record<number, TreatmentPlanItemStatus> = {};
   processingItemIds = new Set<number>();
@@ -64,7 +62,6 @@ export class TreatmentPlanDetailComponent {
   readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
   readonly itemStatusLabels = TREATMENT_PLAN_ITEM_STATUS_LABELS;
   readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
-  readonly statusOptions = Object.values(TreatmentPlanStatus);
   readonly itemStatusOptions = Object.values(TreatmentPlanItemStatus);
 
   constructor(
@@ -105,7 +102,6 @@ export class TreatmentPlanDetailComponent {
     this.treatmentPlanService.getTreatmentPlanDetail(this.treatmentPlanId).subscribe({
       next: response => {
         this.treatmentPlan = response.data;
-        this.selectedStatus = response.data?.status ?? null;
         this.syncSelectedItemStatuses();
         this.spinner.hide();
       },
@@ -181,45 +177,6 @@ export class TreatmentPlanDetailComponent {
       },
       error: error => {
         this.spinner.hide();
-        this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
-      }
-    });
-  }
-
-  confirmStatusUpdate(): void {
-    if (!this.selectedStatus || !this.treatmentPlan || this.selectedStatus === this.treatmentPlan.status) {
-      return;
-    }
-
-    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
-      data: {
-        title: 'Actualizar estado',
-        message: `¿Seguro que quieres cambiar el estado del plan a ${this.getStatusLabel(this.selectedStatus)}?`,
-        confirmText: 'Actualizar'
-      }
-    });
-
-    dialogRef.afterClosed().subscribe(result => {
-      if (result) {
-        this.updateTreatmentPlanStatus({
-          status: this.selectedStatus as TreatmentPlanStatus
-        });
-      } else {
-        this.selectedStatus = this.treatmentPlan?.status ?? null;
-      }
-    });
-  }
-
-  updateTreatmentPlanStatus(payload: UpdateTreatmentPlanStatusRequest): void {
-    this.spinner.show();
-    this.treatmentPlanService.updateTreatmentPlanStatus(this.treatmentPlanId, payload).subscribe({
-      next: response => {
-        this.openSnackbar(response.message || 'Estado del plan actualizado correctamente', 'Ok');
-        this.loadTreatmentPlanDetail();
-      },
-      error: error => {
-        this.spinner.hide();
-        this.selectedStatus = this.treatmentPlan?.status ?? null;
         this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
       }
     });
@@ -379,10 +336,6 @@ export class TreatmentPlanDetailComponent {
         this.openSnackbar(`Ocurrio un error: ${this.getErrorMessage(error)}`, 'Ok');
       }
     });
-  }
-
-  isStatusChanged(): boolean {
-    return !!this.selectedStatus && !!this.treatmentPlan && this.selectedStatus !== this.treatmentPlan.status;
   }
 
   getStatusLabel(status: TreatmentPlanStatus): string {

--- a/src/app/shared/dialogs/confirm-dialog/confirm-dialog.component.html
+++ b/src/app/shared/dialogs/confirm-dialog/confirm-dialog.component.html
@@ -4,5 +4,5 @@
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button mat-dialog-close color="warn">Cancelar</button>
-  <button mat-button color="primary" (click)="confirm()">Eliminar</button>
+  <button mat-button color="primary" (click)="confirm()">{{data.confirmText || 'Eliminar'}}</button>
 </mat-dialog-actions>

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.html
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.html
@@ -2,6 +2,25 @@
 
 <mat-dialog-content class="treatment-plan-item-dialog-content">
     <form [formGroup]="itemForm">
+        @if (mode === 'status') {
+        <div class="status-row">
+            <div class="current-status">
+                <span class="status-label">Estado actual</span>
+                <span class="status-value">{{currentStatusLabel}}</span>
+            </div>
+
+            <mat-form-field class="status-field" appearance="outline">
+                <mat-label>Cambiar estado a</mat-label>
+                <mat-select formControlName="status">
+                    @for (status of statusOptions; track status) {
+                    <mat-option [value]="status">{{getStatusLabel(status)}}</mat-option>
+                    }
+                </mat-select>
+            </mat-form-field>
+        </div>
+        }
+
+        @if (mode !== 'status') {
         <mat-form-field class="full-width" appearance="outline">
             <mat-label>Concepto existente</mat-label>
             <mat-select formControlName="userConceptId" (selectionChange)="onConceptChange($event.value)">
@@ -81,6 +100,7 @@
             <span>Subtotal estimado</span>
             <strong>{{getPreviewSubtotal() | currency:'MXN':'symbol':'1.2-2'}}</strong>
         </div>
+        }
     </form>
 </mat-dialog-content>
 

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.html
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.html
@@ -1,0 +1,90 @@
+<h2 mat-dialog-title class="dialog-title">{{dialogTitle}}</h2>
+
+<mat-dialog-content class="treatment-plan-item-dialog-content">
+    <form [formGroup]="itemForm">
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Concepto existente</mat-label>
+            <mat-select formControlName="userConceptId" (selectionChange)="onConceptChange($event.value)">
+                <mat-option [value]="null">Captura manual</mat-option>
+                @for (concept of conceptList; track concept.id) {
+                <mat-option [value]="concept.id">{{concept.description}} - {{concept.unit_price | currency:'MXN':'symbol':'1.2-2'}}</mat-option>
+                }
+            </mat-select>
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Nombre</mat-label>
+            <input matInput formControlName="name">
+            @if (itemForm.controls['name'].hasError('required') && itemForm.controls['name'].touched) {
+            <mat-error>Este campo es obligatorio</mat-error>
+            }
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Descripcion</mat-label>
+            <textarea matInput rows="2" formControlName="description"></textarea>
+        </mat-form-field>
+
+        <div class="row-fields">
+            <mat-form-field class="half-width" appearance="outline">
+                <mat-label>Diente</mat-label>
+                <input matInput formControlName="tooth">
+            </mat-form-field>
+
+            <mat-form-field class="half-width" appearance="outline">
+                <mat-label>Area</mat-label>
+                <input matInput formControlName="area">
+            </mat-form-field>
+        </div>
+
+        <div class="row-fields">
+            <mat-form-field class="half-width" appearance="outline">
+                <mat-label>Cantidad</mat-label>
+                <input matInput type="number" min="0.01" formControlName="quantity">
+                @if (itemForm.controls['quantity'].invalid && itemForm.controls['quantity'].touched) {
+                <mat-error>La cantidad debe ser mayor a 0</mat-error>
+                }
+            </mat-form-field>
+
+            <mat-form-field class="half-width" appearance="outline">
+                <mat-label>Precio unitario</mat-label>
+                <input matInput type="number" min="0" formControlName="unitPrice">
+                @if (itemForm.controls['unitPrice'].invalid && itemForm.controls['unitPrice'].touched) {
+                <mat-error>El precio no puede ser negativo</mat-error>
+                }
+            </mat-form-field>
+        </div>
+
+        <div class="row-fields">
+            <mat-form-field class="half-width" appearance="outline">
+                <mat-label>Fase</mat-label>
+                <input matInput formControlName="phase">
+            </mat-form-field>
+
+            <mat-form-field class="half-width" appearance="outline">
+                <mat-label>Prioridad</mat-label>
+                <mat-select formControlName="priority">
+                    <mat-option [value]="null">Sin prioridad</mat-option>
+                    @for (priority of priorityOptions; track priority) {
+                    <mat-option [value]="priority">{{getPriorityLabel(priority)}}</mat-option>
+                    }
+                </mat-select>
+            </mat-form-field>
+        </div>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Notas</mat-label>
+            <textarea matInput rows="2" formControlName="notes"></textarea>
+        </mat-form-field>
+
+        <div class="preview-subtotal">
+            <span>Subtotal estimado</span>
+            <strong>{{getPreviewSubtotal() | currency:'MXN':'symbol':'1.2-2'}}</strong>
+        </div>
+    </form>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+    <button mat-button (click)="cancel()" color="warn">Cancelar</button>
+    <button mat-button (click)="saveItem()" color="primary">Guardar</button>
+</mat-dialog-actions>

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.scss
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.scss
@@ -1,0 +1,65 @@
+@use "../../../../vars.scss" as *;
+
+.dialog-title {
+  color: $primary--blue;
+}
+
+.treatment-plan-item-dialog-content {
+  padding-top: 10px !important;
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.row-fields {
+  display: flex;
+  gap: 16px;
+}
+
+.half-width {
+  width: 50%;
+}
+
+.preview-subtotal {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  border: 1px solid #C0D9FF;
+  padding: 12px;
+  margin-bottom: 8px;
+  font-family: 'Roboto';
+  color: #7A7A7A;
+}
+
+.preview-subtotal strong {
+  color: $main--blue;
+}
+
+:host ::ng-deep .mdc-text-field--focused {
+  background-color: transparent;
+}
+
+:host ::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-form-field-focus-overlay {
+  opacity: 0;
+}
+
+:host ::ng-deep .mdc-text-field:not(.mdc-text-field--disabled) .mdc-floating-label {
+  color: #6CA6FE;
+}
+
+:host ::ng-deep .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+  color: #6CA6FE;
+}
+
+@media (max-width: 768px) {
+  .row-fields {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .half-width {
+    width: 100%;
+  }
+}

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.scss
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.scss
@@ -37,6 +37,40 @@
   color: $main--blue;
 }
 
+.status-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.current-status {
+  width: 50%;
+  min-height: 56px;
+  border: 1px solid #C0D9FF;
+  border-radius: 4px;
+  padding: 8px 12px;
+}
+
+.status-label {
+  display: block;
+  font-family: 'Roboto Condensed';
+  font-size: 13px;
+  line-height: 16px;
+  color: $main--blue;
+  margin-bottom: 6px;
+}
+
+.status-value {
+  font-family: 'Roboto';
+  font-size: 14px;
+  line-height: 20px;
+  color: #7A7A7A;
+}
+
+.status-field {
+  width: 50%;
+}
+
 :host ::ng-deep .mdc-text-field--focused {
   background-color: transparent;
 }
@@ -59,7 +93,14 @@
     gap: 0;
   }
 
-  .half-width {
+  .half-width,
+  .current-status,
+  .status-field {
     width: 100%;
+  }
+
+  .status-row {
+    flex-direction: column;
+    gap: 0;
   }
 }

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.spec.ts
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreatmentPlanItemMgmtDialogComponent } from './treatment-plan-item-mgmt-dialog.component';
+
+describe('TreatmentPlanItemMgmtDialogComponent', () => {
+  let component: TreatmentPlanItemMgmtDialogComponent;
+  let fixture: ComponentFixture<TreatmentPlanItemMgmtDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TreatmentPlanItemMgmtDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TreatmentPlanItemMgmtDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.ts
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.ts
@@ -10,14 +10,16 @@ import { UserConcept } from '../../../core/models/user-concept.model';
 import {
   CreateTreatmentPlanItemRequest,
   TREATMENT_PLAN_ITEM_PRIORITY_LABELS,
+  TREATMENT_PLAN_ITEM_STATUS_LABELS,
   TreatmentPlanItem,
   TreatmentPlanItemPriority,
+  TreatmentPlanItemStatus,
   UpdateTreatmentPlanItemRequest
 } from '../../../core/models/treatment-plan.model';
 
 export interface TreatmentPlanItemMgmtDialogData {
-  conceptList: UserConcept[];
-  mode?: 'create' | 'edit';
+  conceptList?: UserConcept[];
+  mode?: 'create' | 'edit' | 'status';
   treatmentPlanItem?: TreatmentPlanItem;
 }
 
@@ -38,9 +40,11 @@ export interface TreatmentPlanItemMgmtDialogData {
 export class TreatmentPlanItemMgmtDialogComponent {
   itemForm: FormGroup;
   conceptList: UserConcept[] = [];
-  mode: 'create' | 'edit';
+  mode: 'create' | 'edit' | 'status';
   readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
+  readonly statusLabels = TREATMENT_PLAN_ITEM_STATUS_LABELS;
   readonly priorityOptions = Object.values(TreatmentPlanItemPriority);
+  readonly statusOptions = Object.values(TreatmentPlanItemStatus);
 
   constructor(
     private fb: FormBuilder,
@@ -60,6 +64,7 @@ export class TreatmentPlanItemMgmtDialogComponent {
       phase: [''],
       priority: [null],
       notes: [''],
+      status: [data?.treatmentPlanItem?.status ?? TreatmentPlanItemStatus.PENDING, Validators.required],
     });
 
     if (data?.treatmentPlanItem) {
@@ -84,6 +89,17 @@ export class TreatmentPlanItemMgmtDialogComponent {
   }
 
   saveItem(): void {
+    if (this.mode === 'status') {
+      const statusControl = this.itemForm.controls['status'];
+      if (statusControl.invalid) {
+        statusControl.markAsTouched();
+        return;
+      }
+
+      this.dialogRef.close({ status: statusControl.value });
+      return;
+    }
+
     if (this.itemForm.invalid) {
       this.itemForm.markAllAsTouched();
       return;
@@ -114,8 +130,21 @@ export class TreatmentPlanItemMgmtDialogComponent {
     return this.priorityLabels[priority] ?? priority;
   }
 
+  getStatusLabel(status: TreatmentPlanItemStatus): string {
+    return this.statusLabels[status] ?? status;
+  }
+
   get dialogTitle(): string {
+    if (this.mode === 'status') {
+      return 'Editar Estado del Tratamiento';
+    }
+
     return this.mode === 'edit' ? 'Editar Tratamiento' : 'Agregar Tratamiento';
+  }
+
+  get currentStatusLabel(): string {
+    const status = this.data?.treatmentPlanItem?.status;
+    return status ? this.getStatusLabel(status) : '--';
   }
 
   getPreviewSubtotal(): number {
@@ -141,6 +170,7 @@ export class TreatmentPlanItemMgmtDialogComponent {
       phase: item.phase,
       priority: item.priority,
       notes: item.notes,
+      status: item.status,
     });
   }
 }

--- a/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.ts
+++ b/src/app/shared/dialogs/treatment-plan-item-mgmt-dialog/treatment-plan-item-mgmt-dialog.component.ts
@@ -1,0 +1,146 @@
+import { CommonModule } from '@angular/common';
+import { Component, Inject } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
+import { UserConcept } from '../../../core/models/user-concept.model';
+import {
+  CreateTreatmentPlanItemRequest,
+  TREATMENT_PLAN_ITEM_PRIORITY_LABELS,
+  TreatmentPlanItem,
+  TreatmentPlanItemPriority,
+  UpdateTreatmentPlanItemRequest
+} from '../../../core/models/treatment-plan.model';
+
+export interface TreatmentPlanItemMgmtDialogData {
+  conceptList: UserConcept[];
+  mode?: 'create' | 'edit';
+  treatmentPlanItem?: TreatmentPlanItem;
+}
+
+@Component({
+  selector: 'app-treatment-plan-item-mgmt-dialog',
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatSelectModule,
+    ReactiveFormsModule
+  ],
+  templateUrl: './treatment-plan-item-mgmt-dialog.component.html',
+  styleUrl: './treatment-plan-item-mgmt-dialog.component.scss'
+})
+export class TreatmentPlanItemMgmtDialogComponent {
+  itemForm: FormGroup;
+  conceptList: UserConcept[] = [];
+  mode: 'create' | 'edit';
+  readonly priorityLabels = TREATMENT_PLAN_ITEM_PRIORITY_LABELS;
+  readonly priorityOptions = Object.values(TreatmentPlanItemPriority);
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<TreatmentPlanItemMgmtDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: TreatmentPlanItemMgmtDialogData | null
+  ) {
+    this.conceptList = data?.conceptList ?? [];
+    this.mode = data?.mode ?? 'create';
+    this.itemForm = this.fb.group({
+      userConceptId: [null],
+      name: ['', Validators.required],
+      description: [''],
+      tooth: [''],
+      area: [''],
+      quantity: [1, [Validators.required, Validators.min(0.01)]],
+      unitPrice: [0, [Validators.required, Validators.min(0)]],
+      phase: [''],
+      priority: [null],
+      notes: [''],
+    });
+
+    if (data?.treatmentPlanItem) {
+      this.patchTreatmentPlanItem(data.treatmentPlanItem);
+    }
+  }
+
+  onConceptChange(conceptId: number | null): void {
+    if (!conceptId) {
+      return;
+    }
+
+    const selectedConcept = this.conceptList.find(concept => concept.id === conceptId);
+    if (!selectedConcept) {
+      return;
+    }
+
+    this.itemForm.patchValue({
+      name: String(selectedConcept.description ?? ''),
+      unitPrice: Number(selectedConcept.unit_price ?? 0),
+    });
+  }
+
+  saveItem(): void {
+    if (this.itemForm.invalid) {
+      this.itemForm.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.itemForm.value;
+    const payload: CreateTreatmentPlanItemRequest | UpdateTreatmentPlanItemRequest = {
+      user_concept_id: formValue.userConceptId || null,
+      name: formValue.name.trim(),
+      description: this.toNullableString(formValue.description),
+      tooth: this.toNullableString(formValue.tooth),
+      area: this.toNullableString(formValue.area),
+      quantity: Number(formValue.quantity),
+      unit_price: Number(formValue.unitPrice),
+      phase: this.toNullableString(formValue.phase),
+      priority: formValue.priority || null,
+      notes: this.toNullableString(formValue.notes),
+    };
+
+    this.dialogRef.close(payload);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+  getPriorityLabel(priority: TreatmentPlanItemPriority): string {
+    return this.priorityLabels[priority] ?? priority;
+  }
+
+  get dialogTitle(): string {
+    return this.mode === 'edit' ? 'Editar Tratamiento' : 'Agregar Tratamiento';
+  }
+
+  getPreviewSubtotal(): number {
+    const quantity = Number(this.itemForm.controls['quantity'].value) || 0;
+    const unitPrice = Number(this.itemForm.controls['unitPrice'].value) || 0;
+    return quantity * unitPrice;
+  }
+
+  private toNullableString(value: string | null | undefined): string | null {
+    const normalizedValue = value?.trim();
+    return normalizedValue ? normalizedValue : null;
+  }
+
+  private patchTreatmentPlanItem(item: TreatmentPlanItem): void {
+    this.itemForm.patchValue({
+      userConceptId: item.user_concept_id,
+      name: item.name,
+      description: item.description,
+      tooth: item.tooth,
+      area: item.area,
+      quantity: Number(item.quantity),
+      unitPrice: Number(item.unit_price),
+      phase: item.phase,
+      priority: item.priority,
+      notes: item.notes,
+    });
+  }
+}

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.html
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.html
@@ -1,0 +1,67 @@
+<h2 mat-dialog-title class="dialog-title">Nuevo Plan de Tratamiento</h2>
+
+<mat-dialog-content class="treatment-plan-dialog-content">
+    <form [formGroup]="treatmentPlanForm">
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Titulo</mat-label>
+            <input matInput formControlName="title">
+            @if (treatmentPlanForm.controls['title'].hasError('required') && treatmentPlanForm.controls['title'].touched) {
+            <mat-error>Este campo es obligatorio</mat-error>
+            }
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Descripcion</mat-label>
+            <textarea matInput rows="3" formControlName="description"></textarea>
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Diagnostico</mat-label>
+            <textarea matInput rows="2" formControlName="diagnosis"></textarea>
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Motivo de consulta</mat-label>
+            <textarea matInput rows="2" formControlName="patientComplaint"></textarea>
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Observaciones clinicas</mat-label>
+            <textarea matInput rows="2" formControlName="clinicalObservations"></textarea>
+        </mat-form-field>
+
+        <mat-form-field class="full-width" appearance="outline">
+            <mat-label>Pronostico</mat-label>
+            <textarea matInput rows="2" formControlName="prognosis"></textarea>
+        </mat-form-field>
+
+        <div class="date-row">
+            <mat-form-field class="date-field" appearance="outline">
+                <mat-label>Inicio estimado</mat-label>
+                <input matInput [matDatepicker]="startPicker" formControlName="estimatedStartDate">
+                <mat-datepicker-toggle matIconSuffix [for]="startPicker"></mat-datepicker-toggle>
+                <mat-datepicker #startPicker></mat-datepicker>
+            </mat-form-field>
+
+            <mat-form-field class="date-field" appearance="outline">
+                <mat-label>Fin estimado</mat-label>
+                <input matInput [matDatepicker]="endPicker" formControlName="estimatedEndDate">
+                <mat-datepicker-toggle matIconSuffix [for]="endPicker"></mat-datepicker-toggle>
+                <mat-datepicker #endPicker></mat-datepicker>
+            </mat-form-field>
+        </div>
+
+        <mat-form-field class="discount-field" appearance="outline">
+            <mat-label>Descuento</mat-label>
+            <input matInput type="number" min="0" formControlName="discount">
+            @if (treatmentPlanForm.controls['discount'].hasError('min') && treatmentPlanForm.controls['discount'].touched) {
+            <mat-error>El descuento no puede ser negativo</mat-error>
+            }
+        </mat-form-field>
+    </form>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+    <button mat-button (click)="cancel()" color="warn">Cancelar</button>
+    <button mat-button (click)="saveTreatmentPlan()" color="primary">Guardar</button>
+</mat-dialog-actions>

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.html
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.html
@@ -61,6 +61,24 @@
             <mat-error>El descuento no puede ser negativo</mat-error>
             }
         </mat-form-field>
+
+        @if (mode === 'edit') {
+        <div class="status-row">
+            <div class="current-status">
+                <span class="status-label">Estado actual</span>
+                <span class="status-value">{{currentStatusLabel}}</span>
+            </div>
+
+            <mat-form-field class="status-field" appearance="outline">
+                <mat-label>Cambiar estado a</mat-label>
+                <mat-select formControlName="status">
+                    @for (status of statusOptions; track status) {
+                    <mat-option [value]="status">{{getStatusLabel(status)}}</mat-option>
+                    }
+                </mat-select>
+            </mat-form-field>
+        </div>
+        }
     </form>
 </mat-dialog-content>
 

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.html
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.html
@@ -1,4 +1,4 @@
-<h2 mat-dialog-title class="dialog-title">Nuevo Plan de Tratamiento</h2>
+<h2 mat-dialog-title class="dialog-title">{{dialogTitle}}</h2>
 
 <mat-dialog-content class="treatment-plan-dialog-content">
     <form [formGroup]="treatmentPlanForm">
@@ -48,6 +48,9 @@
                 <input matInput [matDatepicker]="endPicker" formControlName="estimatedEndDate">
                 <mat-datepicker-toggle matIconSuffix [for]="endPicker"></mat-datepicker-toggle>
                 <mat-datepicker #endPicker></mat-datepicker>
+                @if (treatmentPlanForm.hasError('dateRange') && treatmentPlanForm.controls['estimatedEndDate'].touched) {
+                <mat-error>La fecha fin no puede ser anterior a la fecha inicio</mat-error>
+                }
             </mat-form-field>
         </div>
 

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.scss
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.scss
@@ -26,6 +26,40 @@
   width: 50%;
 }
 
+.status-row {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+.current-status {
+  width: 50%;
+  min-height: 56px;
+  border: 1px solid #C0D9FF;
+  border-radius: 4px;
+  padding: 8px 12px;
+}
+
+.status-label {
+  display: block;
+  font-family: 'Roboto Condensed';
+  font-size: 13px;
+  line-height: 16px;
+  color: $main--blue;
+  margin-bottom: 6px;
+}
+
+.status-value {
+  font-family: 'Roboto';
+  font-size: 14px;
+  line-height: 20px;
+  color: #7A7A7A;
+}
+
+.status-field {
+  width: 50%;
+}
+
 :host ::ng-deep .mdc-text-field--focused {
   background-color: transparent;
 }
@@ -49,7 +83,14 @@
   }
 
   .date-field,
-  .discount-field {
+  .discount-field,
+  .current-status,
+  .status-field {
     width: 100%;
+  }
+
+  .status-row {
+    flex-direction: column;
+    gap: 0;
   }
 }

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.scss
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.scss
@@ -1,0 +1,55 @@
+@use "../../../../vars.scss" as *;
+
+.dialog-title {
+  color: $primary--blue;
+}
+
+.treatment-plan-dialog-content {
+  padding-top: 10px !important;
+}
+
+.full-width {
+  width: 100%;
+  margin-bottom: 10px;
+}
+
+.date-row {
+  display: flex;
+  gap: 16px;
+}
+
+.date-field {
+  width: 50%;
+}
+
+.discount-field {
+  width: 50%;
+}
+
+:host ::ng-deep .mdc-text-field--focused {
+  background-color: transparent;
+}
+
+:host ::ng-deep .mat-mdc-form-field.mat-focused .mat-mdc-form-field-focus-overlay {
+  opacity: 0;
+}
+
+:host ::ng-deep .mdc-text-field:not(.mdc-text-field--disabled) .mdc-floating-label {
+  color: #6CA6FE;
+}
+
+:host ::ng-deep .mdc-text-field--focused:not(.mdc-text-field--disabled) .mdc-floating-label {
+  color: #6CA6FE;
+}
+
+@media (max-width: 768px) {
+  .date-row {
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .date-field,
+  .discount-field {
+    width: 100%;
+  }
+}

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.spec.ts
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TreatmentPlanMgmtDialogComponent } from './treatment-plan-mgmt-dialog.component';
+
+describe('TreatmentPlanMgmtDialogComponent', () => {
+  let component: TreatmentPlanMgmtDialogComponent;
+  let fixture: ComponentFixture<TreatmentPlanMgmtDialogComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TreatmentPlanMgmtDialogComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(TreatmentPlanMgmtDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.ts
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.ts
@@ -1,12 +1,18 @@
 import { CommonModule } from '@angular/common';
-import { Component } from '@angular/core';
-import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { Component, Inject } from '@angular/core';
+import { AbstractControl, FormBuilder, FormGroup, ReactiveFormsModule, ValidationErrors, ValidatorFn, Validators } from '@angular/forms';
 import { MatButtonModule } from '@angular/material/button';
 import { MatDatepickerModule } from '@angular/material/datepicker';
-import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
-import { CreateTreatmentPlanRequest } from '../../../core/models/treatment-plan.model';
+import moment from 'moment';
+import { CreateTreatmentPlanRequest, TreatmentPlan, UpdateTreatmentPlanRequest } from '../../../core/models/treatment-plan.model';
+
+export interface TreatmentPlanMgmtDialogData {
+  mode?: 'create' | 'edit';
+  treatmentPlan?: TreatmentPlan;
+}
 
 @Component({
   selector: 'app-treatment-plan-mgmt-dialog',
@@ -24,11 +30,14 @@ import { CreateTreatmentPlanRequest } from '../../../core/models/treatment-plan.
 })
 export class TreatmentPlanMgmtDialogComponent {
   treatmentPlanForm: FormGroup;
+  mode: 'create' | 'edit';
 
   constructor(
     private fb: FormBuilder,
-    public dialogRef: MatDialogRef<TreatmentPlanMgmtDialogComponent>
+    public dialogRef: MatDialogRef<TreatmentPlanMgmtDialogComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: TreatmentPlanMgmtDialogData | null
   ) {
+    this.mode = data?.mode ?? 'create';
     this.treatmentPlanForm = this.fb.group({
       title: ['', Validators.required],
       description: [''],
@@ -39,7 +48,11 @@ export class TreatmentPlanMgmtDialogComponent {
       estimatedStartDate: [null],
       estimatedEndDate: [null],
       discount: [null, [Validators.min(0)]],
-    });
+    }, { validators: this.dateRangeValidator() });
+
+    if (data?.treatmentPlan) {
+      this.patchTreatmentPlan(data.treatmentPlan);
+    }
   }
 
   saveTreatmentPlan(): void {
@@ -49,7 +62,7 @@ export class TreatmentPlanMgmtDialogComponent {
     }
 
     const formValue = this.treatmentPlanForm.value;
-    const payload: CreateTreatmentPlanRequest = {
+    const payload: CreateTreatmentPlanRequest | UpdateTreatmentPlanRequest = {
       title: formValue.title.trim(),
       description: this.toNullableString(formValue.description),
       diagnosis: this.toNullableString(formValue.diagnosis),
@@ -71,6 +84,24 @@ export class TreatmentPlanMgmtDialogComponent {
     this.dialogRef.close();
   }
 
+  get dialogTitle(): string {
+    return this.mode === 'edit' ? 'Editar Plan de Tratamiento' : 'Nuevo Plan de Tratamiento';
+  }
+
+  private patchTreatmentPlan(treatmentPlan: TreatmentPlan): void {
+    this.treatmentPlanForm.patchValue({
+      title: treatmentPlan.title,
+      description: treatmentPlan.description,
+      diagnosis: treatmentPlan.diagnosis,
+      patientComplaint: treatmentPlan.patient_complaint,
+      clinicalObservations: treatmentPlan.clinical_observations,
+      prognosis: treatmentPlan.prognosis,
+      estimatedStartDate: this.toDatepickerValue(treatmentPlan.estimated_start_date),
+      estimatedEndDate: this.toDatepickerValue(treatmentPlan.estimated_end_date),
+      discount: treatmentPlan.discount !== null && treatmentPlan.discount !== undefined ? Number(treatmentPlan.discount) : null,
+    });
+  }
+
   private toNullableString(value: string | null | undefined): string | null {
     const normalizedValue = value?.trim();
     return normalizedValue ? normalizedValue : null;
@@ -90,5 +121,37 @@ export class TreatmentPlanMgmtDialogComponent {
     }
 
     return String(value);
+  }
+
+  private toDatepickerValue(value: string | null): any {
+    return value ? moment(value) : null;
+  }
+
+  private dateRangeValidator(): ValidatorFn {
+    return (control: AbstractControl): ValidationErrors | null => {
+      const startDate = control.get('estimatedStartDate')?.value;
+      const endDate = control.get('estimatedEndDate')?.value;
+
+      if (!startDate || !endDate) {
+        return null;
+      }
+
+      const normalizedStartDate = this.toComparableDate(startDate);
+      const normalizedEndDate = this.toComparableDate(endDate);
+
+      return normalizedEndDate < normalizedStartDate ? { dateRange: true } : null;
+    };
+  }
+
+  private toComparableDate(value: any): string {
+    if (typeof value.format === 'function') {
+      return value.format('YYYY-MM-DD');
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString().split('T')[0];
+    }
+
+    return String(value).split('T')[0];
   }
 }

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.ts
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.ts
@@ -1,0 +1,94 @@
+import { CommonModule } from '@angular/common';
+import { Component } from '@angular/core';
+import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
+import { MatButtonModule } from '@angular/material/button';
+import { MatDatepickerModule } from '@angular/material/datepicker';
+import { MatDialogModule, MatDialogRef } from '@angular/material/dialog';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { CreateTreatmentPlanRequest } from '../../../core/models/treatment-plan.model';
+
+@Component({
+  selector: 'app-treatment-plan-mgmt-dialog',
+  imports: [
+    CommonModule,
+    MatButtonModule,
+    MatDatepickerModule,
+    MatDialogModule,
+    MatFormFieldModule,
+    MatInputModule,
+    ReactiveFormsModule
+  ],
+  templateUrl: './treatment-plan-mgmt-dialog.component.html',
+  styleUrl: './treatment-plan-mgmt-dialog.component.scss'
+})
+export class TreatmentPlanMgmtDialogComponent {
+  treatmentPlanForm: FormGroup;
+
+  constructor(
+    private fb: FormBuilder,
+    public dialogRef: MatDialogRef<TreatmentPlanMgmtDialogComponent>
+  ) {
+    this.treatmentPlanForm = this.fb.group({
+      title: ['', Validators.required],
+      description: [''],
+      diagnosis: [''],
+      patientComplaint: [''],
+      clinicalObservations: [''],
+      prognosis: [''],
+      estimatedStartDate: [null],
+      estimatedEndDate: [null],
+      discount: [null, [Validators.min(0)]],
+    });
+  }
+
+  saveTreatmentPlan(): void {
+    if (this.treatmentPlanForm.invalid) {
+      this.treatmentPlanForm.markAllAsTouched();
+      return;
+    }
+
+    const formValue = this.treatmentPlanForm.value;
+    const payload: CreateTreatmentPlanRequest = {
+      title: formValue.title.trim(),
+      description: this.toNullableString(formValue.description),
+      diagnosis: this.toNullableString(formValue.diagnosis),
+      patient_complaint: this.toNullableString(formValue.patientComplaint),
+      clinical_observations: this.toNullableString(formValue.clinicalObservations),
+      prognosis: this.toNullableString(formValue.prognosis),
+      estimated_start_date: this.formatDateValue(formValue.estimatedStartDate),
+      estimated_end_date: this.formatDateValue(formValue.estimatedEndDate),
+    };
+
+    if (formValue.discount !== null && formValue.discount !== '') {
+      payload.discount = Number(formValue.discount);
+    }
+
+    this.dialogRef.close(payload);
+  }
+
+  cancel(): void {
+    this.dialogRef.close();
+  }
+
+  private toNullableString(value: string | null | undefined): string | null {
+    const normalizedValue = value?.trim();
+    return normalizedValue ? normalizedValue : null;
+  }
+
+  private formatDateValue(value: any): string | null {
+    if (!value) {
+      return null;
+    }
+
+    if (typeof value.format === 'function') {
+      return value.format('YYYY-MM-DD');
+    }
+
+    if (value instanceof Date) {
+      return value.toISOString().split('T')[0];
+    }
+
+    return String(value);
+  }
+}

--- a/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.ts
+++ b/src/app/shared/dialogs/treatment-plan-mgmt-dialog/treatment-plan-mgmt-dialog.component.ts
@@ -6,12 +6,24 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MAT_DIALOG_DATA, MatDialogModule, MatDialogRef } from '@angular/material/dialog';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
+import { MatSelectModule } from '@angular/material/select';
 import moment from 'moment';
-import { CreateTreatmentPlanRequest, TreatmentPlan, UpdateTreatmentPlanRequest } from '../../../core/models/treatment-plan.model';
+import {
+  CreateTreatmentPlanRequest,
+  TREATMENT_PLAN_STATUS_LABELS,
+  TreatmentPlan,
+  TreatmentPlanStatus,
+  UpdateTreatmentPlanRequest
+} from '../../../core/models/treatment-plan.model';
 
 export interface TreatmentPlanMgmtDialogData {
   mode?: 'create' | 'edit';
   treatmentPlan?: TreatmentPlan;
+}
+
+export interface TreatmentPlanMgmtDialogResult {
+  treatmentPlan: CreateTreatmentPlanRequest | UpdateTreatmentPlanRequest;
+  status?: TreatmentPlanStatus;
 }
 
 @Component({
@@ -23,6 +35,7 @@ export interface TreatmentPlanMgmtDialogData {
     MatDialogModule,
     MatFormFieldModule,
     MatInputModule,
+    MatSelectModule,
     ReactiveFormsModule
   ],
   templateUrl: './treatment-plan-mgmt-dialog.component.html',
@@ -31,6 +44,8 @@ export interface TreatmentPlanMgmtDialogData {
 export class TreatmentPlanMgmtDialogComponent {
   treatmentPlanForm: FormGroup;
   mode: 'create' | 'edit';
+  readonly statusLabels = TREATMENT_PLAN_STATUS_LABELS;
+  readonly statusOptions = Object.values(TreatmentPlanStatus);
 
   constructor(
     private fb: FormBuilder,
@@ -48,6 +63,7 @@ export class TreatmentPlanMgmtDialogComponent {
       estimatedStartDate: [null],
       estimatedEndDate: [null],
       discount: [null, [Validators.min(0)]],
+      status: [data?.treatmentPlan?.status ?? TreatmentPlanStatus.DRAFT],
     }, { validators: this.dateRangeValidator() });
 
     if (data?.treatmentPlan) {
@@ -77,7 +93,15 @@ export class TreatmentPlanMgmtDialogComponent {
       payload.discount = Number(formValue.discount);
     }
 
-    this.dialogRef.close(payload);
+    const result: TreatmentPlanMgmtDialogResult = {
+      treatmentPlan: payload
+    };
+
+    if (this.mode === 'edit') {
+      result.status = formValue.status;
+    }
+
+    this.dialogRef.close(result);
   }
 
   cancel(): void {
@@ -86,6 +110,15 @@ export class TreatmentPlanMgmtDialogComponent {
 
   get dialogTitle(): string {
     return this.mode === 'edit' ? 'Editar Plan de Tratamiento' : 'Nuevo Plan de Tratamiento';
+  }
+
+  get currentStatusLabel(): string {
+    const status = this.data?.treatmentPlan?.status;
+    return status ? this.getStatusLabel(status) : '--';
+  }
+
+  getStatusLabel(status: TreatmentPlanStatus): string {
+    return this.statusLabels[status] ?? status;
   }
 
   private patchTreatmentPlan(treatmentPlan: TreatmentPlan): void {
@@ -99,6 +132,7 @@ export class TreatmentPlanMgmtDialogComponent {
       estimatedStartDate: this.toDatepickerValue(treatmentPlan.estimated_start_date),
       estimatedEndDate: this.toDatepickerValue(treatmentPlan.estimated_end_date),
       discount: treatmentPlan.discount !== null && treatmentPlan.discount !== undefined ? Number(treatmentPlan.discount) : null,
+      status: treatmentPlan.status,
     });
   }
 


### PR DESCRIPTION
## Feature: Planes de Tratamiento

Se integra el flujo de planes de tratamiento para pacientes, incluyendo listado, detalle, creación, edición, cambio de estado y administración de tratamientos/items.

### Cambios principales

- Se agregó listado de planes de tratamiento por paciente con paginación.
- Se agregó filtro por estado en el listado.
- Por defecto se ocultan los planes cancelados usando el filtro `Activos`.
- Se agregó acción para cancelar/eliminar lógicamente un plan de tratamiento con confirmación.
- Se agregó pantalla de detalle del plan con información general, clínica, fechas, resumen financiero e items.
- Se agregó creación y edición de planes mediante diálogo.
- Se movió el cambio de estado del plan al diálogo de edición.
- Se agregó creación de tratamientos/items dentro del plan.
- Se ajustó la edición de estado de items para realizarse desde diálogo.
- Se mantuvo eliminación de items mediante confirmación.
- Se reorganizó el dashboard del paciente para incluir Planes de Tratamiento de forma balanceada.

### Validación

- Build de desarrollo ejecutado correctamente:

```bash
npm run build -- --configuration development